### PR TITLE
Limit Engine level for iOS and Android

### DIFF
--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -53,8 +53,8 @@ cordova plugin add $plugin_directory/tests/attachments --link
 cordova plugin add $plugin_directory/tests/dbcreateencrypted --link
 
 echo "Adding platforms..."
-cordova platform add ios
-cordova platform add android
+cordova platform add ios@4.0
+cordova platform add android@5.0
 
 echo "Patching platform assets..."
 cp -f $patch_directory/Podfile $platform_ios_directory/Podfile

--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -30,6 +30,11 @@
     <js-module src="www/datastoremanager.js" name="DatastoreManager"/>
     <js-module src="www/replicatorbuilder.js" name="ReplicatorBuilder" />
 
+    <engines>
+        <engine name="cordova-android" version=">=5.0.0" />
+        <engine name="cordova-ios" version=">=4.0.0" />
+    </engines>
+
     <!-- ios -->
     <platform name="ios">
         <config-file target="config.xml" parent="/*">


### PR DESCRIPTION
## What

Limit Cordova Engine level to stop iOS library being included on platforms below iOS 7.
## How
- Limit the Engine level for iOS to 4.0.x
  -  Lowest supported deployment target is iOS 7
- Limit the engine level for android to 5.0.x
  - Needed to be done because iOS level was limited.
## Reviewers

reviewer @brynh 
## Issues

Fixes #12
