### PR TITLE
Pull sync-android jars from maven central

### DIFF
--- a/plugin/assets/sync-extras.gradle
+++ b/plugin/assets/sync-extras.gradle
@@ -13,14 +13,8 @@
  *
  */
 
-repositories {
-		maven { url "http://cloudant.github.io/cloudant-sync-eap/repository/" }
-}
-
 dependencies {
-		compile group: 'com.cloudant', name: 'cloudant-sync-datastore-core', version:'0.13.4'
-		compile group: 'com.cloudant', name: 'cloudant-sync-datastore-android', version:'0.13.4'
-		compile group: 'com.cloudant', name: 'cloudant-sync-datastore-android-encryption', version:'0.13.4'
+		compile group: 'com.cloudant', name: 'cloudant-sync-datastore-android-encryption', version:'0.15.+'
 }
 
 android {


### PR DESCRIPTION
## What

Pull sync-android jars from maven central
## How
- Modify sync extras gradle file to remove the repositories and unneeded dependencies.
- Upgrade sync-android to 0.15 release, using the place holder to pick up patch releases.
## Notes

Due to android packaging and the inclusion of license files in the jars, the sync android jar cannot be included by just the `framework` xml tag in `plugin.xml`.
## Reviewers
## Issues

Fixes #4
