### PR TITLE
Rename plugin to cloudant-sync

### DIFF
--- a/libs/utils.js
+++ b/libs/utils.js
@@ -12,8 +12,8 @@
  * and limitations under the License.
  *
  */
- 
-var _ = require('com.cloudant.sync.underscore');
+
+var _ = require('cloudant-sync.underscore');
 
 var lastTimestamp = 0;
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -15,7 +15,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    id="com.cloudant.sync"
+    id="cloudant-sync"
     version="0.1.0">
     <name>Cloudant Sync</name>
     <description>Cloudant Sync Cordova Plugin</description>

--- a/tests/attachments/AttachmentsTests.js
+++ b/tests/attachments/AttachmentsTests.js
@@ -13,8 +13,8 @@
  *
  */
 
-var DatastoreManager = require( 'com.cloudant.sync.DatastoreManager' );
-var Q = require('com.cloudant.sync.q');
+var DatastoreManager = require( 'cloudant-sync.DatastoreManager' );
+var Q = require('cloudant-sync.q');
 
 var DBName = "cruddb";
 var EncryptedDBName = DBName + "secure";

--- a/tests/attachments/plugin.xml
+++ b/tests/attachments/plugin.xml
@@ -11,7 +11,7 @@
  either express or implied. See the License for the specific language governing permissions
  and limitations under the License.
  -->
- 
+
 <?xml version="1.0" encoding="UTF-8" ?>
 <plugin id="com.cloudant.sync.test.attachments" version="0.1.0-dev" xmlns:android="http://schemas.android.com/apk/res/android" xmlns="http://apache.org/cordova/ns/plugins/1.0">
     <name>Cloudant Sync Plugin Attachments Tests</name>
@@ -19,7 +19,7 @@
     <repo>https://github.com/cloudant/sync-cordova-plugin#:plugin/tests/attachments</repo>
 
     <dependency id="cordova-plugin-test-framework"/>
-    <dependency id="com.cloudant.sync" url=".."/>
+    <dependency id="cloudant-sync" url=".."/>
 
     <js-module name="tests" src="AttachmentsTests.js"/>
 

--- a/tests/crud/CRUDTests.js
+++ b/tests/crud/CRUDTests.js
@@ -13,7 +13,7 @@
  *
  */
 
-var DatastoreManager = require( 'com.cloudant.sync.DatastoreManager' );
+var DatastoreManager = require( 'cloudant-sync.DatastoreManager' );
 var DBName = "cruddb";
 var EncryptedDBName = DBName + "secure";
 exports.defineAutoTests = function() {

--- a/tests/crud/plugin.xml
+++ b/tests/crud/plugin.xml
@@ -11,7 +11,7 @@
  either express or implied. See the License for the specific language governing permissions
  and limitations under the License.
  -->
- 
+
 <?xml version="1.0" encoding="UTF-8" ?>
 <plugin id="com.cloudant.sync.test.crud" version="0.1.0-dev" xmlns:android="http://schemas.android.com/apk/res/android" xmlns="http://apache.org/cordova/ns/plugins/1.0">
     <name>Cloudant Sync Plugin CRUD Tests</name>
@@ -19,7 +19,7 @@
     <repo>https://github.com/cloudant/sync-cordova-plugin#:plugin/tests</repo>
 
     <dependency id="cordova-plugin-test-framework"/>
-    <dependency id="com.cloudant.sync" url=".."/>
+    <dependency id="cloudant-sync" url=".."/>
     <js-module name="tests" src="CRUDTests.js"/>
 
 </plugin>

--- a/tests/dbcreate/DBCreateTests.js
+++ b/tests/dbcreate/DBCreateTests.js
@@ -13,7 +13,7 @@
  *
  */
 
-var DatastoreManager = require('com.cloudant.sync.DatastoreManager');
+var DatastoreManager = require('cloudant-sync.DatastoreManager');
 var DBName = "testdbcreate";
 exports.defineAutoTests = function() {
     describe('DatastoreManager', function() {

--- a/tests/dbcreate/plugin.xml
+++ b/tests/dbcreate/plugin.xml
@@ -11,7 +11,7 @@
  either express or implied. See the License for the specific language governing permissions
  and limitations under the License.
  -->
- 
+
 <?xml version="1.0" encoding="UTF-8" ?>
 <plugin id="com.cloudant.sync.test.dbcreate" version="0.1.0-dev" xmlns:android="http://schemas.android.com/apk/res/android" xmlns="http://apache.org/cordova/ns/plugins/1.0">
     <name>Cloudant Sync Plugin Create/Delete Datastore Tests</name>
@@ -19,7 +19,7 @@
     <repo>https://github.com/cloudant/sync-cordova-plugin#:plugin/tests</repo>
 
     <dependency id="cordova-plugin-test-framework"/>
-    <dependency id="com.cloudant.sync" url=".."/>
+    <dependency id="cloudant-sync" url=".."/>
     <js-module name="tests" src="DBCreateTests.js"/>
 
 </plugin>

--- a/tests/dbcreateencrypted/DBCreateEncryptedTests.js
+++ b/tests/dbcreateencrypted/DBCreateEncryptedTests.js
@@ -13,7 +13,7 @@
  *
  */
 
-var DatastoreManager = require('com.cloudant.sync.DatastoreManager');
+var DatastoreManager = require('cloudant-sync.DatastoreManager');
 var DBName = "testdbcreateencrypted";
 exports.defineAutoTests = function() {
     describe('DatastoreManager', function() {

--- a/tests/dbcreateencrypted/plugin.xml
+++ b/tests/dbcreateencrypted/plugin.xml
@@ -11,7 +11,7 @@
  either express or implied. See the License for the specific language governing permissions
  and limitations under the License.
  -->
- 
+
 <?xml version="1.0" encoding="UTF-8" ?>
 <plugin id="com.cloudant.sync.test.dbcreateencrypted" version="0.1.0-dev" xmlns:android="http://schemas.android.com/apk/res/android" xmlns="http://apache.org/cordova/ns/plugins/1.0">
     <name>Cloudant Sync Plugin DB Create Encrypted Tests</name>
@@ -19,7 +19,7 @@
     <repo>https://github.com/cloudant/sync-cordova-plugin#:plugin/tests</repo>
 
     <dependency id="cordova-plugin-test-framework"/>
-    <dependency id="com.cloudant.sync" url=".."/>
+    <dependency id="cloudant-sync" url=".."/>
     <js-module name="tests" src="DBCreateEncryptedTests.js"/>
 
 </plugin>

--- a/tests/indexandquery/IndexAndQueryTests.js
+++ b/tests/indexandquery/IndexAndQueryTests.js
@@ -13,8 +13,8 @@
  *
  */
 
-var DatastoreManager = require('com.cloudant.sync.DatastoreManager');
-var Q = require('com.cloudant.sync.q');
+var DatastoreManager = require('cloudant-sync.DatastoreManager');
+var Q = require('cloudant-sync.q');
 
 var DBName = "indexandquerydb";
 var encryptedDBName = DBName + "secure";

--- a/tests/indexandquery/plugin.xml
+++ b/tests/indexandquery/plugin.xml
@@ -11,7 +11,7 @@
  either express or implied. See the License for the specific language governing permissions
  and limitations under the License.
  -->
- 
+
 <?xml version="1.0" encoding="UTF-8" ?>
 <plugin id="com.cloudant.sync.test.indexandquery" version="0.1.0-dev" xmlns:android="http://schemas.android.com/apk/res/android" xmlns="http://apache.org/cordova/ns/plugins/1.0">
     <name>Cloudant Sync Plugin Index and Query Tests</name>
@@ -19,7 +19,7 @@
     <repo>https://github.com/cloudant/sync-cordova-plugin#:plugin/tests</repo>
 
     <dependency id="cordova-plugin-test-framework"/>
-    <dependency id="com.cloudant.sync" url=".."/>
+    <dependency id="cloudant-sync" url=".."/>
     <js-module name="tests" src="IndexAndQueryTests.js"/>
 
 </plugin>

--- a/tests/replication/ReplicationTests.js
+++ b/tests/replication/ReplicationTests.js
@@ -16,13 +16,13 @@
 var DBName = "replicationdb";
 var EncryptedDBName = DBName + "secure";
 try {
-    var DatastoreManager = require('com.cloudant.sync.DatastoreManager');
-    var ReplicatorBuilder = require('com.cloudant.sync.ReplicatorBuilder');
+    var DatastoreManager = require('cloudant-sync.DatastoreManager');
+    var ReplicatorBuilder = require('cloudant-sync.ReplicatorBuilder');
 } catch (e) {
     console.log("error: " + e);
 }
-var TestUtil = require('com.cloudant.sync.test.common.TestUtil');
-var Q = require('com.cloudant.sync.q');
+var TestUtil = require('cloudant-sync.test.common.TestUtil');
+var Q = require('cloudant-sync.q');
 
 exports.defineAutoTests = function() {
 

--- a/tests/replication/plugin.xml
+++ b/tests/replication/plugin.xml
@@ -19,7 +19,7 @@
     <repo>https://hub.jazz.net/git/imfsdk/CloudantToolkit-Hybrid#:plugin/tests/replication</repo>
 
     <dependency id="cordova-plugin-test-framework"/>
-    <dependency id="com.cloudant.sync" url=".."/>
+    <dependency id="cloudant-sync" url=".."/>
     <dependency id="com.cloudant.sync.test.common" url=".."/>
     <js-module name="tests" src="ReplicationTests.js"/>
 

--- a/www/datastoremanager.js
+++ b/www/datastoremanager.js
@@ -14,13 +14,13 @@
  */
 
 var exec = require('cordova/exec');
-var Q = require('com.cloudant.sync.q');
-var _ = require('com.cloudant.sync.underscore');
-var utils = require('com.cloudant.sync.utils');
+var Q = require('cloudant-sync.q');
+var _ = require('cloudant-sync.underscore');
+var utils = require('cloudant-sync.utils');
 
 /**
  * @class DatastoreManager
- * @description <p><strong>var DatastoreManager = require('com.cloudant.sync.DatastoreManager')</strong></p>
+ * @description <p><strong>var DatastoreManager = require('cloudant-sync.DatastoreManager')</strong></p>
  * @classdesc The {@link DatastoreManager} module is an interface for managing a set of {@link Datastore} objects.
  */
 

--- a/www/httpinterceptors.js
+++ b/www/httpinterceptors.js
@@ -13,7 +13,7 @@
  *
  */
 
-var utils = require('com.cloudant.sync.utils');
+var utils = require('cloudant-sync.utils');
 
 /**
  * @class HttpInterceptorContext

--- a/www/replicator.js
+++ b/www/replicator.js
@@ -14,11 +14,11 @@
  */
 
 var exec = require('cordova/exec');
-var Q = require('com.cloudant.sync.q');
-var _ = require('com.cloudant.sync.underscore');
-var utils = require('com.cloudant.sync.utils');
-var Datastore = require('com.cloudant.sync.DatastoreManager').Datastore;
-var HttpInterceptorContext = require('com.cloudant.sync.HttpInterceptorContext');
+var Q = require('cloudant-sync.q');
+var _ = require('cloudant-sync.underscore');
+var utils = require('cloudant-sync.utils');
+var Datastore = require('cloudant-sync.DatastoreManager').Datastore;
+var HttpInterceptorContext = require('cloudant-sync.HttpInterceptorContext');
 
 module.exports = Replicator;
 

--- a/www/replicatorbuilder.js
+++ b/www/replicatorbuilder.js
@@ -13,11 +13,11 @@
  *
  */
 
-var Q = require('com.cloudant.sync.q');
-var _ = require('com.cloudant.sync.underscore');
-var utils = require('com.cloudant.sync.utils');
-var Datastore = require('com.cloudant.sync.DatastoreManager').Datastore;
-var Replicator = require('com.cloudant.sync.Replicator');
+var Q = require('cloudant-sync.q');
+var _ = require('cloudant-sync.underscore');
+var utils = require('cloudant-sync.utils');
+var Datastore = require('cloudant-sync.DatastoreManager').Datastore;
+var Replicator = require('cloudant-sync.Replicator');
 
 /**
  * @class ReplicatorBuilder


### PR DESCRIPTION
Rename the plug-in to `cloudant-sync`. 

Note: This does change the documentation that will completed later as part of a separate ticket.

Fixes #31

reviewer @brynh 
