### PR TITLE
Enable plug-in to be built with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+language: android
+
+services:
+    - couchdb
+
+android:
+  components:
+    # Uncomment the lines below if you want to
+    # use the latest revision of Android SDK Tools
+    - platform-tools
+    - tools
+
+    # The BuildTools version used by your project
+    - build-tools-19.1.0
+
+    # The SDK version used to compile your project
+    - android-23
+
+    # Additional components
+    - extra-google-m2repository
+    - extra-android-m2repository
+
+    # Specify at least one system image,
+    # if you need to run emulator(s) during your tests
+    - sys-img-x86-android-21
+    - sys-img-armeabi-v7a-android-21
+
+before_script:
+    - npm install -g "git+ssh://git@github.com:rhyshort/cordova-paramedic.git"
+    - npm install -g cordova
+    - ./setup.rb
+    #- echo no | android create avd --force -n test -t android-21 --abi x86
+    - echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a
+    - emulator -avd test -no-audio -no-window &
+    - android-wait-for-emulator
+
+script:
+    - cordova-paramedic --platform 'android@5.0' --plugin . --verbose --timeout 3000000

--- a/setup.rb
+++ b/setup.rb
@@ -1,0 +1,5 @@
+#!/usr/bin/ruby
+
+system("curl -X POST http://127.0.0.1:5984/_replicate -H 'Content-Type: application/json' -d '{\"source\": \"http://clientlibs-test.cloudant.com/animaldb\",\"target\": \"http://localhost:5984/animaldb\",\"create_target\": true,\"continuous\": false}'")
+
+exit $?.to_i

--- a/tests/Tests.js
+++ b/tests/Tests.js
@@ -5,11 +5,13 @@ var dbCreateEncrypted = require('cloudant-sync-tests.DBCreateEncryptedTests');
 var indexAndQuery = require('cloudant-sync-tests.IndexAndQueryTests');
 var replication = require('cloudant-sync-tests.ReplicationTests');
 
-exports.defineAutoTests = function (){
-    dbCreate.defineAutoTests();
-     attachments.defineAutoTests();
-     crud.defineAutoTests();
-     dbCreateEncrypted.defineAutoTests();
-     indexAndQuery.defineAutoTests();
-     replication.defineAutoTests();
-}
+exports.defineAutoTests = function () {
+  // time out in milliseconds
+  jasmine.DEFAULT_TIMEOUT_INTERVAL = 480000;
+  dbCreate.defineAutoTests();
+  attachments.defineAutoTests();
+  crud.defineAutoTests();
+  dbCreateEncrypted.defineAutoTests();
+  indexAndQuery.defineAutoTests();
+  replication.defineAutoTests();
+};


### PR DESCRIPTION
- Add travis.yml
  - Only contains androud support
  - it needs to use arm emulator since x86 is not supported on travis.
- Add set up script to replicate anmialdb from cloudant
- Increase jasmine timeout so tests have a large oppertunity to pass.

reviewer @mikerhodes 
