### PR TITLE
Make it possible to specify where the datastores should be placed on disk.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -32,6 +32,9 @@
     <js-module src="www/replicator.js" name="Replicator" />
     <js-module src="www/httpinterceptors.js" name="HttpInterceptorContext"/>
 
+    <!-- Cordova deps -->
+    <dependency id="cordova-plugin-file" />
+
     <engines>
         <engine name="cordova-android" version=">=5.0.0" />
         <engine name="cordova-ios" version=">=4.0.0" />

--- a/src/android/SyncPluginInterceptor.java
+++ b/src/android/SyncPluginInterceptor.java
@@ -111,7 +111,7 @@ class SyncPluginInterceptor implements HttpConnectionRequestInterceptor, HttpCon
 
         // Lock and wait for JavaScript to respond
         try {
-            responseLatch.await(5, TimeUnit.MINUTES);
+            responseLatch.await(60, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             Log.e(TAG, "Replication interceptor timed out", e);
         }
@@ -176,7 +176,7 @@ class SyncPluginInterceptor implements HttpConnectionRequestInterceptor, HttpCon
 
         // Lock and wait for JavaScript to respond
         try {
-            requestLatch.await(5, TimeUnit.MINUTES);
+            requestLatch.await(60, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             Log.e(TAG, "Replication interceptor timed out", e);
         }

--- a/src/ios/CDTSyncPlugin.h
+++ b/src/ios/CDTSyncPlugin.h
@@ -16,8 +16,6 @@
 #import <UIKit/UIKit.h>
 #import <Cordova/CDVPlugin.h>
 
-#define kIMFDataLocalStoreDirectory    @"hybriddatastores"
-
 @interface CDTSyncPlugin : CDVPlugin
 
 -(void)openDatastore:(CDVInvokedUrlCommand*)command;
@@ -47,5 +45,7 @@
 -(void)getReplicationStatus:(CDVInvokedUrlCommand*)command;
 
 -(void)unlockInterceptor:(CDVInvokedUrlCommand*)command;
+
+-(void)createDatastoreManager:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/ios/CDTSyncPluginInterceptor.m
+++ b/src/ios/CDTSyncPluginInterceptor.m
@@ -100,7 +100,7 @@
 
     // Lock and wait for JavaScript to response
     dispatch_semaphore_t jsCallbackSemaphore = dispatch_semaphore_create(0);
-    dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 5*(60*NSEC_PER_SEC));
+    dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 60*NSEC_PER_SEC);
 
     // Cache the lock and context for use in updateContext
     [self.mapLock lock];
@@ -181,7 +181,7 @@
 
     // Lock and wait for JavaScript to response
     dispatch_semaphore_t jsCallbackSemaphore = dispatch_semaphore_create(0);
-    dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 5*(60*NSEC_PER_SEC));
+    dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 60*NSEC_PER_SEC);
 
     // Cache the lock and context for use in updateContext
     [self.mapLock lock];

--- a/tests/AttachmentsTests.js
+++ b/tests/AttachmentsTests.js
@@ -13,655 +13,668 @@
  *
  */
 
-var DatastoreManager = require( 'cloudant-sync.DatastoreManager' );
+var DatastoreManager = require('cloudant-sync.DatastoreManager').DatastoreManager;
 var Q = require('cloudant-sync.q');
 
-var DBName = "cruddb";
-var EncryptedDBName = DBName + "secure";
+var DBName = 'cruddb';
+var EncryptedDBName = DBName + 'secure';
 
 exports.defineAutoTests = function() {
-    describe('Datastore', function() {
+  describe('Datastore', function() {
 
-        var validEncryptionOptions = {
-            password: 'passw0rd',
-            identifier: 'toolkit'
-        };
+    var validEncryptionOptions = {
+      password: 'passw0rd',
+      identifier: 'toolkit',
+    };
+    var manager;
+    var localStore = null;
 
-        var localStore = null;
+    var storeName = null;
 
-        var storeName = null;
+    var todd_image = '/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/2wBDAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wAARCABDAEsDARIAAhEBAxEB/8QAHAAAAgMBAQEBAAAAAAAAAAAABwkABggKCwQF/8QAMhAAAQQBAwMDAwMDBAMAAAAAAwECBAUGBxESAAgTFCEiCRUxChYjMjNBJDRhgUJRcf/EABQBAQAAAAAAAAAAAAAAAAAAAAD/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwDk17TtY9RMIPaYlpnR5Gayykb6vNLCuyeCapdS3VjGHFk2GH3VNMqSV1W6ACb6gUtbQJYk8wPFBnXA5WWcFyPMNN7R99i0skWTMgyaee1o2kUlbKGnqwlV7CjE1WOd4z8fIPd42uaOQZjw2FnJq6myxmOSJE37nWzxTKQWM2AY7MjGeOT+cw6+JPsPTTrl82edPFGLdmD5kCyqa9JGNa6XfSsoJka2741sQpZKziP5yhrYMkQHjhonyb4YJyiHwTxxoyIzZoWojgs+SVEKdZyfRRmwiN8yGSwmx3vlnfIOryNaoIaqiOIRnnRpFM9rlRF236/AyGFJBYqjD+ZqgFFiPORgSqQQ/crjO2EASH4I3kjQhG1Vc8QRu4BX5WLXhLEFFFhusrKW4siOKG4ZOYiflrTPVjGIFGtUriEYxrmp7qjmJ12H/Rw/TrW/eZiOJ9x/cbd5DpP233lNTX+mEChBCpdae4jH72pizZ+SxpBfuNnphpDILIFCx/KiNBqHmJIp7ikrcPx0VNdZYHHDHxC8FZRnFprV4AWA2S3xIcqSxvpJbGyXAkxgkG5WuE9vlEr2827jcvt163lX9EL6LmmWPDq7vs10XyJkYUWvHkep78iz/N7kkh3ijksMkyq6sb62spBxvjRTkO+UYAnKFrABG3oPJUtrudLkZA4EI7ELKRF8o1UscJHeFqTNxr4CGe3mnmVFe96ARFUat69Gfvf/AEx3aTqPphlMjsRyEGhufKaZlFXo/neW3WX6T6hTkhGt4+IRry5lWmc6Stt4rQx8elUNhfYdTQ5EecfB7GI9kd4eb4HiCMxxoopSte9CgKSRHQ3NvAbVcEoFaoiOYXkx7ORBNG5rxuex+8dU+3ul0rXIMI1Vxu10l1JwDNsmxnUbG58F87MMTs6GXGhmxO3rmSZLSWqypQptbMjltqafipq23x2yuK/IKe5KGDIJhUl1V2DxjmFr51dYPAZqEjFSDMjyXwpI3exgHYFWFZsibP8AZEROi1O04vj0Uq5g0sYmMMtRxBXUtZkO49OeV4x2a0U5secJSR1cUgXqXZ7CRkQqqx7gEOS5LY5PdTrmaVnklSDqAQGNjR4MJ5SqCuhhE1gxxI4SIJEVvkKrfKYhHue51izWoq4l7KjUEci1kMceN5kcU5Cvaj/KcznsYgjG5N2YqcERqI1f6k6D4K6JirIUb7nczY81w/KcEatjyBB8yuKIaGIJ7nvaF40Lu5UQqPa3ZqNa38llbPexrgx+YlREY5fyrW/FN/8AlNtv8/j8r+eg9Gpv0q/03CARpNZMoQ/srmxO5vuYkNcirsrSCQvkRiruqfFiqnJeS8F4pv8APZIjDtlyStdu1v8AMR2yJybx2Rdvxs135RdtuW6qjQcBI+mR+mshv4s1J1Fe5W+3DXzuxIwjV3RW+UD2t8buKp+d0bsu6/hyh45rAh43jVxObhNRrzlevkG7Zzfk9rWo1dkf/S1rN0TffdoN2J9NT9NlM4eTOMvlRSIkYq2muneLNhSGmVovQnBJKSHNjSxvJEkwjIo5ICkAo3I9eOBsEp7rPMuqaNt5jGMiBWv+62uRTD1eOQKWmKlvNmznQ4VpI8zyjZCCeDXSphyyo4n+OGsiQAHBZP366511zqfFi38Slp4VxVwMJh4xFZAhxMXqiFj41BKLiMq1cWojQDBpyjZGVSPHYxyewhKkyjUYOnOIychyAIre6vSmnCGZLGcZHmKUoki1dYE9hYPaFohgihHxYIXMitG1V6A2ZD3mdx8nJ769yvOpueSZQnEoJOVR/IXHTkZ4Y8+niQFg1gnhG4qBEWAcD0ejVRRtRnWLcF1lh6rgsJtfC9TPrwq89VEizI0+HHAxxOMqntY0KdAIxOXEb2EG73a1W7K1oNY0O749dKPHbCPINH/dMqc5tTmNiCXLsKqqkyWFl18QE1769RO8YUaRohuiDixhRvGwLGMVTgXeRjWQ3cjCJsX1MePJUMScr7mKEBlf4/GCzLVBo3TfKz5w1sHufxRnJpHM5AznONOPpdd2U6NrP9SCNe4x3G3ImVdsmn+U90VHUZZS4oyNU43mMyBo1k9PiRL+ZWujV06fPjEyaSGqgim2RosOCGOtbWKBkVvXz8hMNhabGbqBileV0+J67bIK9tpHEtSkltg+Cj2uCO4SO+uWe8Ve6SkxzRdBuiZ2W/px/URpLiapTyRmEaxZOXfUJsDx/Kr90CcOqcdY6kVqETxK5UV7CO4P24q7bXlKEaBHIbxD5X83OG5yNX4tGnByIu6bfJ3BCL7r7KrQZJO7N/05AFcD9tamk9VxcRzLj6hskMleScfUcdeGOXZdvkQa7bI5NkTfpZk6qKrWSPVK9XqR7NnLwRg3O4tTi9zn8morSqrkTze7URiNe4GPN7N/04GybYfqH/6/3n1DU90/O6Lr61UXfff4p7/jdPfpZb4bxOVhLVw3IiKrHEmbpyajkVeHx+TVR26bb8t1RFXboCMwrOKDWbSowZGt38Z0VUV+6oJNkawTPf3VHK/ffZN06F0duUoVrTScUE5VXk10zJSqT5KiJu3GlaJqLu9Ebuqqu7lXbboC9FnUlHLLZ3FzGZAMYA1QchgGNVysY0QnSgcBsJxanBz/AJkV6q5znI3ocyJ88kBa848P8TnN80gk7JJKK9rnKPcL6WM5yDd8t0Xbdu2y7K1oajp7arhWQiVc4zSXUeJRxGkGx8UZJ5H+uFNdu18yPMe2Ao44HxyDa0nAzmuXjkk+QW6QQww/tjkx4kWe2wy9yucApnDc0CVzWRyfyu8kgRVIREGx3FrOLQ2vlII1tQnp7GBClCEN6tZx9gb7sTxSVcslrA7J42tKrmtYxHOV3J3VGojWkzT6qkzSRGzptC08c0VZZI8iO00uHFNvNQUt7COh/wAnkarnqm6Pc1Uf0Fb0iJhGmEyzmApY1hMN62VJgxiyIw5kcLxMlEmWAxlMaQYbyAiRGF5q/criORrU6G76bOKqtbX3hKTKpx5cmRVW0Y4MTIGOQ7zRo9jUxY8wEmTCjvSOUkNBLKQPmcFrzOY0LZprQYFQZdcX1FWRlr5U+RLixpXlOGESc9JLFLVS/JFbKa0npin8XJpWeUfjUisbXsMqMppiXJcwuINpIkzjzog62EyNErIJ/G2PUiOn+rsVjiE0hZ01xDGlHN4kDHQIAAXtQKq6s6O1uxTY0IFrkeOyIDGh5PRtKYHmCYR2eBsdqFeWO0SkRzlehXi3axo7znI8nbEWkDLx6CCBJe1PWtyaZIGV6o4o3RgyhxAv9muN6ZRCcRvxG53zcFVoiWhJUplxkjJcVJUlwPDTVUNQxnP5IzkxspG7P3dsjW8lTmiclf0ORWORxXEVLPHJDzM35pUZGVrmjVeLkR1w1U3VNkVXPft8kau2zgMcawx+1q1JDu7yWSBJNBSS474bREiqoyiaBldFRUCu40/ie3Zfi56pyaFPuOYACeQ2ThrQIcCv88S6hSSmkuf40BB/cCSJTVUJPOYIyNjsRFkuE17HOAqkHUNerXGs1VEaiqy4mq32an9KuYrtv/v/AFsnt0DSWWWke97rHDd3OVfajyXZG7/FPjkCNXZuyckTZ35TbfoGfYF9O/uc1ToiZXD0tDg2MFCGRXZDqhejwVlnDKJSFl1tKka4yw0eMATpEh02irmujNU8dZLOStM2FfVfs9QbeWG9vJNI3F9Rseo7wdmaJItpuD5fDCPDcjG6EgYr7DF8++44haSYyPJY49Drbm0FGk2U0bQDd39PCNjOoeLab6i60YZi2U5sBjsEqYOM3bYGp00cAlpIx7TLUPKrbHNPr7NIkEZpiYpazqS3mV4zXECJKqherPoSRrFg3cNpnqholqW0cjCf3niw4ktH7WWDVOopjvwLM8eshtYasuNLdY62YWiua94HV1DaCiDIIIY7AAQtLvp19qOi+ouLA15k3uUlyOyra5AZLPpx1FbBjT4RMlJOrqevDUyc0o6Oe2yr60su2hVaRbe1UFjOqoTxLm1l7w77Le17M+2/uOsrnBu4/t6zukPB1xxyqfZ5BeRqaw+14BqnaYpxCmd10owGYnqrAg2VfezcLtoWU1cpsh8yDHDUnevX4VQ62ZjV6Y0NXjGm2OHDh+C0lINEqYGMY2BldVpDcj3KdktwpFm+W97nzJE0x3r/ACJxSBU/Uot7G4sI2uWNrKrfJGZ95w0Rpn2EjIYQFateblKscekmC+ZVzhK6VHDJ9DKFyjK9wbSs7NGoOaUQ3SIm/iVUjkantxVWMKJz0c5FVdt/ZXfF6bdZimd8HbCSGY7MyObi3mkZtJP9Wqon9vxEE1Ef/hVVGtT/AK6DSWHstcsuwJICqDPIRjQCRUbu9yMRVT4qnsqKnt7KmzWtTZXLPzvv9vLgUul0NpJVCKdyrf3nYINbAaSU8K/ZozNxpYka5UC/k5Yip5y+LjzYHSVkPaRoT3HsxnG9Hc3j4T3ETsTrbnKWWttPyfTPLruEOVFvWTGxyobTM5K2vrZwJkE0uuW7to47OoIO4hFan3sC7qk7VjcaXGl1W1TyhiYzVNvryRFpcYrsonsvc8yiZJHGnlnX1tLr6auhRiscGtqqNj2kCxWDcGiNb+xXu20CSynak6F5f+26wzhLmeFCXUHDHiY9UfJFc4sKZOhxkeirINc11W8LP77QsYi9PIwf6mcOjra2Nfah43DyUle+Vc10WcKaAkOIAzyPlx3tG06BBHMMx3AV0nxK9yOUjUcHK1IuoktEPFCksbN/GYSypDXuY7iqNUfKO5Ru3R7ml3avxcjXo5OuhLXi6+mZ3inCXIpeOaC63ZLAdPrNU9OvRY4lw90g0WPOzfEI6hx7Ma48uGcRDS48K/bEZKfTW8YysK0Oc0uRXjSPaOOxBo7ZiJXzm7N/8U2SQqIqJ7Lt+V3XZN9mmfU/ty1h00z7JsHnYdmWTEoJ7QxslwfB8xyfEckq5caPYUuQY9eVwJUWbV3dPLg2cVEkFPFZK9HMVJkY7egw3ric1LrvqhDqCProo8yvhiBDX04hCPcV9o4AWjVEEAc6ZINGAPiGG1RgisDHBHCydBvfTq+thB1LYCaSKO17ZpFrPHDYKGORZQIsm4hzVHFGJg5Ee1E2wGQKCVJbinVVeYvOdANPqAXlrY3GkV/OmEkXN/p3mUC6sHtEkizhwpuFyYYJatGjStjHtrEgFVqOGssqMcxqtY2dArW2/jyCQrERqpFC34oie3jR2222ypyVVX2VPdUXfdep0FGlAilI85INeQyNc9CPr4Tn8kV+y7qBfdNk/wAr/wAIuy8p0Fm03a2dejNLRDPDLDHDyTZgQvRyuYETeIhctkRXMa1yt+Pu1VR06DQ8KQeummJBK+IQcl72Pjqontd7+6OZsq/lU25InH4q1Grt1Og+yTcWoZtucdhLaZcGJFUqne5/pzx4gijRzlcqI8fwVyfJG+zVVFVrZ0FdlW9mS+ijdNkKyLjWC18dvPZBQvQR3enbtt8FcquXlycqueqqvJ6vnQMq0e7rO4+Lp1j8ONrPngIsEl3Ahxx3Z2iiwoGQ2sOFEAxNmjjxYoAx44mIjBBEMbEaxiJ1Og//2Q==';
 
-        var todd_image = "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/2wBDAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wAARCABDAEsDARIAAhEBAxEB/8QAHAAAAgMBAQEBAAAAAAAAAAAABwkABggKCwQF/8QAMhAAAQQBAwMDAwMDBAMAAAAAAwECBAUGBxESAAgTFCEiCRUxChYjMjNBJDRhgUJRcf/EABQBAQAAAAAAAAAAAAAAAAAAAAD/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwDk17TtY9RMIPaYlpnR5Gayykb6vNLCuyeCapdS3VjGHFk2GH3VNMqSV1W6ACb6gUtbQJYk8wPFBnXA5WWcFyPMNN7R99i0skWTMgyaee1o2kUlbKGnqwlV7CjE1WOd4z8fIPd42uaOQZjw2FnJq6myxmOSJE37nWzxTKQWM2AY7MjGeOT+cw6+JPsPTTrl82edPFGLdmD5kCyqa9JGNa6XfSsoJka2741sQpZKziP5yhrYMkQHjhonyb4YJyiHwTxxoyIzZoWojgs+SVEKdZyfRRmwiN8yGSwmx3vlnfIOryNaoIaqiOIRnnRpFM9rlRF236/AyGFJBYqjD+ZqgFFiPORgSqQQ/crjO2EASH4I3kjQhG1Vc8QRu4BX5WLXhLEFFFhusrKW4siOKG4ZOYiflrTPVjGIFGtUriEYxrmp7qjmJ12H/Rw/TrW/eZiOJ9x/cbd5DpP233lNTX+mEChBCpdae4jH72pizZ+SxpBfuNnphpDILIFCx/KiNBqHmJIp7ikrcPx0VNdZYHHDHxC8FZRnFprV4AWA2S3xIcqSxvpJbGyXAkxgkG5WuE9vlEr2827jcvt163lX9EL6LmmWPDq7vs10XyJkYUWvHkep78iz/N7kkh3ijksMkyq6sb62spBxvjRTkO+UYAnKFrABG3oPJUtrudLkZA4EI7ELKRF8o1UscJHeFqTNxr4CGe3mnmVFe96ARFUat69Gfvf/AEx3aTqPphlMjsRyEGhufKaZlFXo/neW3WX6T6hTkhGt4+IRry5lWmc6Stt4rQx8elUNhfYdTQ5EecfB7GI9kd4eb4HiCMxxoopSte9CgKSRHQ3NvAbVcEoFaoiOYXkx7ORBNG5rxuex+8dU+3ul0rXIMI1Vxu10l1JwDNsmxnUbG58F87MMTs6GXGhmxO3rmSZLSWqypQptbMjltqafipq23x2yuK/IKe5KGDIJhUl1V2DxjmFr51dYPAZqEjFSDMjyXwpI3exgHYFWFZsibP8AZEROi1O04vj0Uq5g0sYmMMtRxBXUtZkO49OeV4x2a0U5secJSR1cUgXqXZ7CRkQqqx7gEOS5LY5PdTrmaVnklSDqAQGNjR4MJ5SqCuhhE1gxxI4SIJEVvkKrfKYhHue51izWoq4l7KjUEci1kMceN5kcU5Cvaj/KcznsYgjG5N2YqcERqI1f6k6D4K6JirIUb7nczY81w/KcEatjyBB8yuKIaGIJ7nvaF40Lu5UQqPa3ZqNa38llbPexrgx+YlREY5fyrW/FN/8AlNtv8/j8r+eg9Gpv0q/03CARpNZMoQ/srmxO5vuYkNcirsrSCQvkRiruqfFiqnJeS8F4pv8APZIjDtlyStdu1v8AMR2yJybx2Rdvxs135RdtuW6qjQcBI+mR+mshv4s1J1Fe5W+3DXzuxIwjV3RW+UD2t8buKp+d0bsu6/hyh45rAh43jVxObhNRrzlevkG7Zzfk9rWo1dkf/S1rN0TffdoN2J9NT9NlM4eTOMvlRSIkYq2muneLNhSGmVovQnBJKSHNjSxvJEkwjIo5ICkAo3I9eOBsEp7rPMuqaNt5jGMiBWv+62uRTD1eOQKWmKlvNmznQ4VpI8zyjZCCeDXSphyyo4n+OGsiQAHBZP366511zqfFi38Slp4VxVwMJh4xFZAhxMXqiFj41BKLiMq1cWojQDBpyjZGVSPHYxyewhKkyjUYOnOIychyAIre6vSmnCGZLGcZHmKUoki1dYE9hYPaFohgihHxYIXMitG1V6A2ZD3mdx8nJ769yvOpueSZQnEoJOVR/IXHTkZ4Y8+niQFg1gnhG4qBEWAcD0ejVRRtRnWLcF1lh6rgsJtfC9TPrwq89VEizI0+HHAxxOMqntY0KdAIxOXEb2EG73a1W7K1oNY0O749dKPHbCPINH/dMqc5tTmNiCXLsKqqkyWFl18QE1769RO8YUaRohuiDixhRvGwLGMVTgXeRjWQ3cjCJsX1MePJUMScr7mKEBlf4/GCzLVBo3TfKz5w1sHufxRnJpHM5AznONOPpdd2U6NrP9SCNe4x3G3ImVdsmn+U90VHUZZS4oyNU43mMyBo1k9PiRL+ZWujV06fPjEyaSGqgim2RosOCGOtbWKBkVvXz8hMNhabGbqBileV0+J67bIK9tpHEtSkltg+Cj2uCO4SO+uWe8Ve6SkxzRdBuiZ2W/px/URpLiapTyRmEaxZOXfUJsDx/Kr90CcOqcdY6kVqETxK5UV7CO4P24q7bXlKEaBHIbxD5X83OG5yNX4tGnByIu6bfJ3BCL7r7KrQZJO7N/05AFcD9tamk9VxcRzLj6hskMleScfUcdeGOXZdvkQa7bI5NkTfpZk6qKrWSPVK9XqR7NnLwRg3O4tTi9zn8morSqrkTze7URiNe4GPN7N/04GybYfqH/6/3n1DU90/O6Lr61UXfff4p7/jdPfpZb4bxOVhLVw3IiKrHEmbpyajkVeHx+TVR26bb8t1RFXboCMwrOKDWbSowZGt38Z0VUV+6oJNkawTPf3VHK/ffZN06F0duUoVrTScUE5VXk10zJSqT5KiJu3GlaJqLu9Ebuqqu7lXbboC9FnUlHLLZ3FzGZAMYA1QchgGNVysY0QnSgcBsJxanBz/AJkV6q5znI3ocyJ88kBa848P8TnN80gk7JJKK9rnKPcL6WM5yDd8t0Xbdu2y7K1oajp7arhWQiVc4zSXUeJRxGkGx8UZJ5H+uFNdu18yPMe2Ao44HxyDa0nAzmuXjkk+QW6QQww/tjkx4kWe2wy9yucApnDc0CVzWRyfyu8kgRVIREGx3FrOLQ2vlII1tQnp7GBClCEN6tZx9gb7sTxSVcslrA7J42tKrmtYxHOV3J3VGojWkzT6qkzSRGzptC08c0VZZI8iO00uHFNvNQUt7COh/wAnkarnqm6Pc1Uf0Fb0iJhGmEyzmApY1hMN62VJgxiyIw5kcLxMlEmWAxlMaQYbyAiRGF5q/criORrU6G76bOKqtbX3hKTKpx5cmRVW0Y4MTIGOQ7zRo9jUxY8wEmTCjvSOUkNBLKQPmcFrzOY0LZprQYFQZdcX1FWRlr5U+RLixpXlOGESc9JLFLVS/JFbKa0npin8XJpWeUfjUisbXsMqMppiXJcwuINpIkzjzog62EyNErIJ/G2PUiOn+rsVjiE0hZ01xDGlHN4kDHQIAAXtQKq6s6O1uxTY0IFrkeOyIDGh5PRtKYHmCYR2eBsdqFeWO0SkRzlehXi3axo7znI8nbEWkDLx6CCBJe1PWtyaZIGV6o4o3RgyhxAv9muN6ZRCcRvxG53zcFVoiWhJUplxkjJcVJUlwPDTVUNQxnP5IzkxspG7P3dsjW8lTmiclf0ORWORxXEVLPHJDzM35pUZGVrmjVeLkR1w1U3VNkVXPft8kau2zgMcawx+1q1JDu7yWSBJNBSS474bREiqoyiaBldFRUCu40/ie3Zfi56pyaFPuOYACeQ2ThrQIcCv88S6hSSmkuf40BB/cCSJTVUJPOYIyNjsRFkuE17HOAqkHUNerXGs1VEaiqy4mq32an9KuYrtv/v/AFsnt0DSWWWke97rHDd3OVfajyXZG7/FPjkCNXZuyckTZ35TbfoGfYF9O/uc1ToiZXD0tDg2MFCGRXZDqhejwVlnDKJSFl1tKka4yw0eMATpEh02irmujNU8dZLOStM2FfVfs9QbeWG9vJNI3F9Rseo7wdmaJItpuD5fDCPDcjG6EgYr7DF8++44haSYyPJY49Drbm0FGk2U0bQDd39PCNjOoeLab6i60YZi2U5sBjsEqYOM3bYGp00cAlpIx7TLUPKrbHNPr7NIkEZpiYpazqS3mV4zXECJKqherPoSRrFg3cNpnqholqW0cjCf3niw4ktH7WWDVOopjvwLM8eshtYasuNLdY62YWiua94HV1DaCiDIIIY7AAQtLvp19qOi+ouLA15k3uUlyOyra5AZLPpx1FbBjT4RMlJOrqevDUyc0o6Oe2yr60su2hVaRbe1UFjOqoTxLm1l7w77Le17M+2/uOsrnBu4/t6zukPB1xxyqfZ5BeRqaw+14BqnaYpxCmd10owGYnqrAg2VfezcLtoWU1cpsh8yDHDUnevX4VQ62ZjV6Y0NXjGm2OHDh+C0lINEqYGMY2BldVpDcj3KdktwpFm+W97nzJE0x3r/ACJxSBU/Uot7G4sI2uWNrKrfJGZ95w0Rpn2EjIYQFateblKscekmC+ZVzhK6VHDJ9DKFyjK9wbSs7NGoOaUQ3SIm/iVUjkantxVWMKJz0c5FVdt/ZXfF6bdZimd8HbCSGY7MyObi3mkZtJP9Wqon9vxEE1Ef/hVVGtT/AK6DSWHstcsuwJICqDPIRjQCRUbu9yMRVT4qnsqKnt7KmzWtTZXLPzvv9vLgUul0NpJVCKdyrf3nYINbAaSU8K/ZozNxpYka5UC/k5Yip5y+LjzYHSVkPaRoT3HsxnG9Hc3j4T3ETsTrbnKWWttPyfTPLruEOVFvWTGxyobTM5K2vrZwJkE0uuW7to47OoIO4hFan3sC7qk7VjcaXGl1W1TyhiYzVNvryRFpcYrsonsvc8yiZJHGnlnX1tLr6auhRiscGtqqNj2kCxWDcGiNb+xXu20CSynak6F5f+26wzhLmeFCXUHDHiY9UfJFc4sKZOhxkeirINc11W8LP77QsYi9PIwf6mcOjra2Nfah43DyUle+Vc10WcKaAkOIAzyPlx3tG06BBHMMx3AV0nxK9yOUjUcHK1IuoktEPFCksbN/GYSypDXuY7iqNUfKO5Ru3R7ml3avxcjXo5OuhLXi6+mZ3inCXIpeOaC63ZLAdPrNU9OvRY4lw90g0WPOzfEI6hx7Ma48uGcRDS48K/bEZKfTW8YysK0Oc0uRXjSPaOOxBo7ZiJXzm7N/8U2SQqIqJ7Lt+V3XZN9mmfU/ty1h00z7JsHnYdmWTEoJ7QxslwfB8xyfEckq5caPYUuQY9eVwJUWbV3dPLg2cVEkFPFZK9HMVJkY7egw3ric1LrvqhDqCProo8yvhiBDX04hCPcV9o4AWjVEEAc6ZINGAPiGG1RgisDHBHCydBvfTq+thB1LYCaSKO17ZpFrPHDYKGORZQIsm4hzVHFGJg5Ee1E2wGQKCVJbinVVeYvOdANPqAXlrY3GkV/OmEkXN/p3mUC6sHtEkizhwpuFyYYJatGjStjHtrEgFVqOGssqMcxqtY2dArW2/jyCQrERqpFC34oie3jR2222ypyVVX2VPdUXfdep0FGlAilI85INeQyNc9CPr4Tn8kV+y7qBfdNk/wAr/wAIuy8p0Fm03a2dejNLRDPDLDHDyTZgQvRyuYETeIhctkRXMa1yt+Pu1VR06DQ8KQeummJBK+IQcl72Pjqontd7+6OZsq/lU25InH4q1Grt1Og+yTcWoZtucdhLaZcGJFUqne5/pzx4gijRzlcqI8fwVyfJG+zVVFVrZ0FdlW9mS+ijdNkKyLjWC18dvPZBQvQR3enbtt8FcquXlycqueqqvJ6vnQMq0e7rO4+Lp1j8ONrPngIsEl3Ahxx3Z2iiwoGQ2sOFEAxNmjjxYoAx44mIjBBEMbEaxiJ1Og//2Q==";
+    var dillon_image = '/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAQDAwQDAwQEAwQFBAQFBgoHBgYGBg0JCggKDw0QEA8NDw4RExgUERIXEg4PFRwVFxkZGxsbEBQdHx0aHxgaGxr/2wBDAQQFBQYFBgwHBwwaEQ8RGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhr/wAARCABkAGQDARIAAhEBAxEB/8QAHQAAAAYDAQAAAAAAAAAAAAAAAAMEBgcIAQIFCf/EADoQAAIBAwMCAwYDBgUFAAAAAAECAwAEEQUGIRIxB0FRCBMiYXGBFDKRI0JiobHhFTOCwfA0UnKSk//EABkBAAMBAQEAAAAAAAAAAAAAAAABAgQDBf/EACIRAAICAQQDAQEBAAAAAAAAAAABAhEDBBIhMRMUMkFRYf/aAAwDAQACEQMRAD8AndYqVdHpXngECOj8UDCOjFGkUDCOkZ+dblaYBJXmmVv3xX214eRdOuXnXeuvVHZ2465mHqQPyj5nFFAPLFVI3P7V2t30ija2mQaVAO7XYEzt9lOAPvRTAtqRVYNl+1ZI0yW++NMVYiMC7sSSc+rIf14JooCzpXz9a4+2936FvC1NztvU7bUI1x1iJwWT5MvcfekFHVKUaRx8qVhQlaP1o7pz5UuxUIXhzSp0ooDkTQUtkj8xQI4bwfEaXvFlqKQqHqRistVWdKYWazSsKZoayTRuK2jQ8R94QbF2nf6vPh5UQpbRZ5kmbhVH3/TFMHxe0o7l8RNiaPfqZNKRLu9miP5ZHQKoB/8ApSc0jpjxubpFPdYurvXbue+1K5a8vJmLzzMeZGPf7fLyq0es+Ee2AhMFtJD1MZHCPwxPP/AK5exE3rRSaKnWmjz3xdkHSi9yastN4eaRBGi2cTxIP3Q3DUewP0WuyAX0C2ttMEs7P+JI+FCOPrmpzu9CszGbeWFJIenHSwB4prK2RLTJdEDbX3TqOwt0WOq6TKRLBIOtA2FmjJ+JG+RH6HFdHxB2zJpN579I40tHOIQgxj1yPWtCcXwYpwcPwvVsrd1lvrbVjrmmBkhuVPVE5BaNwcMp+YIxUC+yTrssqbi0aWUskXuruND2UNlTj6lc1MlRyXKLMEelZNSOgpq2YU0JoTOtGMOKZDQhZef7UeV5oFQ5DQNczTtNTQbzoHtNTWD+tA6Ib8VZdQst87dvNLgNzKmnXaJGTgZLR5P9Kcm94hqmoyWTJ0mKxyJAfixI2GA/9K4ymkb8GCT5IIj8TNwNrgsdZbTSkjFQkMhLD79jXTg8NdM/xmO5jghtxGVPSi8tjtXPfGqo9OOHIuWxLvnVdW020YWjpbFhn3hGcD5VvvBBqdxLA/wgfCAeeKqC/pGVS6TIz0jXNVv5yG16N5SeEkjA6vlTqsNkWLQK8kMRcDpEnRzj6103x6Rm8GTts4viHFNd7PWa5RffwyqWK9sZxTs1vSYJNu3lpPIeh4iOpvI+RpxlzZwyYW4mfZEsmbVt1Xwb4Vgt7cqe+cs/9Gro+DdzHtPXtOsNK6WstQc291jBZn6SQ5PyxXV5Nzoy+rOMHKyzJoHz/pSszUzU1g07Cgtu1ZNOyWgkg5rY9/KmSd80Ca5mizU/yrBOaCqs0bnvWfOgsZ27BHbX63XT+0ktGQ5/e6WBA/maJ8TUeDRrfUYwStnODNjyjYYJ+gODXGaN+myVabIduNzLpM9zO11ALsvhY2BcgZye3nSLSNs6fcWmpam93OheRzjAYFfnxWdKmewpSkhn6tu15br3rvDNBIWBYxng+ufI0pe1sNTkeK11EqE46fdjj+Va4NUY8kXd2Ltta+k0LW/vVnCnAYU37SPTtB1K4aOUzOkZPJA6j9OwpOKTslZmlR0t66nG1tDZwMcyt8QXv01wduXC7i3LaQyIZAJ16uMgL1CmzK53yibPCDZLLqJ1u4IeCPDRnGFMpXHwj0AP86m2ONIIUSJAiKAAqjAFNIzZMzfBsTz9K1JqjJzZhq0ZqCaMMQAST2pNdOVj4PfiqRLCJLhi56Tx5UmyPWroih5E1gnmuRqSAOaxnvQWkDtWM0rChPf2cWo2NxZ3SB4LiNo3X1BFbvIEBZiFUDJY8YoKXHRT3clzrHhhrGobfnZ/wD828rr/AJkXkQfM+R/vU4b5fbe+ZIrC9httXtIneETIQypOAGKBh59Jzx5ipcK7Rsx5ZNVZU992yacHltQoMnLcU8NW8KNJtb+aO3SeRFPV0vISAPSqio0EvKyLlub3cF2yWayM7nLdPYfWpV03b7WTJb2NmVUchUXgfU13UW/lGWXH0xVs/R49uWiyr+0uMq7N5s3kKc0Udtodq17qcq5hXq/hT6ep+daI6Ob+uDJLX4o8Q5J72/uK0121xDLF+OhRPxVurZaJmGQCP96pBpvjFqeieI0u6NMAaBwLd7V2IWa2B4VvRs5IPlnyya4zw7eEyVl8nLRfMn70xtleK+2N/WyPo2pRLeED3ljOwSeM+hU9/qOD3ri4tF2h5seaLdsVKBhd0OqLjuDmtS4xg9vOndE0c0uMnOKJldVkYDyNWpE0Prq4on3gA5OB61yNXQTqWq2WkWsl1ql3BZ2qctLNIFUfc1Q/xc3zdb43tq088zPYWV1JaWMOcrGkZ6WbHbLMGOfTFdVjb7OcsiXRPe+/aj0bR/eWuyrU67eDIFxITFbKfrjqb/SD88VUF5CzEZyatY0jm8rHtunxP3XvuRzuHWZjaZ/6S1zBBj06Qcn/AFE0yJJSsL4OAFroopEucmWe9nm40seDu5Z9bmjsrKy1Ka4M5woixyGHzH9qj621y20Dw22roEDOsWszyanemMD/ACQ4Cgg/9xOR69JrvtUuzmpSTtMmXazWW+/xF5b3iCONVNwnSUlGfyhl/cJHkeahLwZ3jJp3iJdWr++S31qJoGVyvEqktGfh4GQXH3FOOnx3bOstVmqkywGqNaabEUjVUjQYCqKa/iDuC12voF3qd0A8qjpgizzJIeFX/npWlZIYlUUYZY55Xc2Ql4v7ye9uzpVsehFw0qg8DPYVFd3cTXtzNcXT+9nmdpJHPmx7/b/as8skpdnSMFHpBYeiWPTySAK5HQUxyFZFdSVkjwUYEhlPyYcj7UniZmYsQQD2zSYEt7S8e95bVEcDX66zZKMe41DLkD0Eg+IffqqKi/JqdqY9zRcrZ3tIbZ3D7u31wPt2+bAxO3VAx/hlHA57BsH5VTJpeO+c+vNS8UWVuZ6N9SXwW4s5EnhkAKvGwZW+hFeeNpuPVtOhEGnatqNlADkRW97LEgP/AIqwFR4v9HuR6dXLEW0xHlG39KFZ0an8nmtHI0jSO5yzSyFj6ksc0K1x+TH+hB8z55oVQBdyT+GkwccUKtAOzcMKxbc0C7TPvjai2BPZY05AHp+Y0K7RJJO9mfRbG9tdUvriBXuYmAR8fl58qFS+wQz/AGgNUup91QWEkhNrBEXRP4mOCf04+9CoKaIiNCgkJl4AI70KkAztjHpQoALdiBQpiCi5yKFNCCmY5oUAf//Z';
 
-        var dillon_image = "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAQDAwQDAwQEAwQFBAQFBgoHBgYGBg0JCggKDw0QEA8NDw4RExgUERIXEg4PFRwVFxkZGxsbEBQdHx0aHxgaGxr/2wBDAQQFBQYFBgwHBwwaEQ8RGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhr/wAARCABkAGQDARIAAhEBAxEB/8QAHQAAAAYDAQAAAAAAAAAAAAAAAAMEBgcIAQIFCf/EADoQAAIBAwMCAwYDBgUFAAAAAAECAwAEEQUGIRIxB0FRCBMiYXGBFDKRI0JiobHhFTOCwfA0UnKSk//EABkBAAMBAQEAAAAAAAAAAAAAAAABAgQDBf/EACIRAAICAQQDAQEBAAAAAAAAAAABAhEDBBIhMRMUMkFRYf/aAAwDAQACEQMRAD8AndYqVdHpXngECOj8UDCOjFGkUDCOkZ+dblaYBJXmmVv3xX214eRdOuXnXeuvVHZ2465mHqQPyj5nFFAPLFVI3P7V2t30ija2mQaVAO7XYEzt9lOAPvRTAtqRVYNl+1ZI0yW++NMVYiMC7sSSc+rIf14JooCzpXz9a4+2936FvC1NztvU7bUI1x1iJwWT5MvcfekFHVKUaRx8qVhQlaP1o7pz5UuxUIXhzSp0ooDkTQUtkj8xQI4bwfEaXvFlqKQqHqRistVWdKYWazSsKZoayTRuK2jQ8R94QbF2nf6vPh5UQpbRZ5kmbhVH3/TFMHxe0o7l8RNiaPfqZNKRLu9miP5ZHQKoB/8ApSc0jpjxubpFPdYurvXbue+1K5a8vJmLzzMeZGPf7fLyq0es+Ee2AhMFtJD1MZHCPwxPP/AK5exE3rRSaKnWmjz3xdkHSi9yastN4eaRBGi2cTxIP3Q3DUewP0WuyAX0C2ttMEs7P+JI+FCOPrmpzu9CszGbeWFJIenHSwB4prK2RLTJdEDbX3TqOwt0WOq6TKRLBIOtA2FmjJ+JG+RH6HFdHxB2zJpN579I40tHOIQgxj1yPWtCcXwYpwcPwvVsrd1lvrbVjrmmBkhuVPVE5BaNwcMp+YIxUC+yTrssqbi0aWUskXuruND2UNlTj6lc1MlRyXKLMEelZNSOgpq2YU0JoTOtGMOKZDQhZef7UeV5oFQ5DQNczTtNTQbzoHtNTWD+tA6Ib8VZdQst87dvNLgNzKmnXaJGTgZLR5P9Kcm94hqmoyWTJ0mKxyJAfixI2GA/9K4ymkb8GCT5IIj8TNwNrgsdZbTSkjFQkMhLD79jXTg8NdM/xmO5jghtxGVPSi8tjtXPfGqo9OOHIuWxLvnVdW020YWjpbFhn3hGcD5VvvBBqdxLA/wgfCAeeKqC/pGVS6TIz0jXNVv5yG16N5SeEkjA6vlTqsNkWLQK8kMRcDpEnRzj6103x6Rm8GTts4viHFNd7PWa5RffwyqWK9sZxTs1vSYJNu3lpPIeh4iOpvI+RpxlzZwyYW4mfZEsmbVt1Xwb4Vgt7cqe+cs/9Gro+DdzHtPXtOsNK6WstQc291jBZn6SQ5PyxXV5Nzoy+rOMHKyzJoHz/pSszUzU1g07Cgtu1ZNOyWgkg5rY9/KmSd80Ca5mizU/yrBOaCqs0bnvWfOgsZ27BHbX63XT+0ktGQ5/e6WBA/maJ8TUeDRrfUYwStnODNjyjYYJ+gODXGaN+myVabIduNzLpM9zO11ALsvhY2BcgZye3nSLSNs6fcWmpam93OheRzjAYFfnxWdKmewpSkhn6tu15br3rvDNBIWBYxng+ufI0pe1sNTkeK11EqE46fdjj+Va4NUY8kXd2Ltta+k0LW/vVnCnAYU37SPTtB1K4aOUzOkZPJA6j9OwpOKTslZmlR0t66nG1tDZwMcyt8QXv01wduXC7i3LaQyIZAJ16uMgL1CmzK53yibPCDZLLqJ1u4IeCPDRnGFMpXHwj0AP86m2ONIIUSJAiKAAqjAFNIzZMzfBsTz9K1JqjJzZhq0ZqCaMMQAST2pNdOVj4PfiqRLCJLhi56Tx5UmyPWroih5E1gnmuRqSAOaxnvQWkDtWM0rChPf2cWo2NxZ3SB4LiNo3X1BFbvIEBZiFUDJY8YoKXHRT3clzrHhhrGobfnZ/wD828rr/AJkXkQfM+R/vU4b5fbe+ZIrC9httXtIneETIQypOAGKBh59Jzx5ipcK7Rsx5ZNVZU992yacHltQoMnLcU8NW8KNJtb+aO3SeRFPV0vISAPSqio0EvKyLlub3cF2yWayM7nLdPYfWpV03b7WTJb2NmVUchUXgfU13UW/lGWXH0xVs/R49uWiyr+0uMq7N5s3kKc0Udtodq17qcq5hXq/hT6ep+daI6Ob+uDJLX4o8Q5J72/uK0121xDLF+OhRPxVurZaJmGQCP96pBpvjFqeieI0u6NMAaBwLd7V2IWa2B4VvRs5IPlnyya4zw7eEyVl8nLRfMn70xtleK+2N/WyPo2pRLeED3ljOwSeM+hU9/qOD3ri4tF2h5seaLdsVKBhd0OqLjuDmtS4xg9vOndE0c0uMnOKJldVkYDyNWpE0Prq4on3gA5OB61yNXQTqWq2WkWsl1ql3BZ2qctLNIFUfc1Q/xc3zdb43tq088zPYWV1JaWMOcrGkZ6WbHbLMGOfTFdVjb7OcsiXRPe+/aj0bR/eWuyrU67eDIFxITFbKfrjqb/SD88VUF5CzEZyatY0jm8rHtunxP3XvuRzuHWZjaZ/6S1zBBj06Qcn/AFE0yJJSsL4OAFroopEucmWe9nm40seDu5Z9bmjsrKy1Ka4M5woixyGHzH9qj621y20Dw22roEDOsWszyanemMD/ACQ4Cgg/9xOR69JrvtUuzmpSTtMmXazWW+/xF5b3iCONVNwnSUlGfyhl/cJHkeahLwZ3jJp3iJdWr++S31qJoGVyvEqktGfh4GQXH3FOOnx3bOstVmqkywGqNaabEUjVUjQYCqKa/iDuC12voF3qd0A8qjpgizzJIeFX/npWlZIYlUUYZY55Xc2Ql4v7ye9uzpVsehFw0qg8DPYVFd3cTXtzNcXT+9nmdpJHPmx7/b/as8skpdnSMFHpBYeiWPTySAK5HQUxyFZFdSVkjwUYEhlPyYcj7UniZmYsQQD2zSYEt7S8e95bVEcDX66zZKMe41DLkD0Eg+IffqqKi/JqdqY9zRcrZ3tIbZ3D7u31wPt2+bAxO3VAx/hlHA57BsH5VTJpeO+c+vNS8UWVuZ6N9SXwW4s5EnhkAKvGwZW+hFeeNpuPVtOhEGnatqNlADkRW97LEgP/AIqwFR4v9HuR6dXLEW0xHlG39KFZ0an8nmtHI0jSO5yzSyFj6ksc0K1x+TH+hB8z55oVQBdyT+GkwccUKtAOzcMKxbc0C7TPvjai2BPZY05AHp+Y0K7RJJO9mfRbG9tdUvriBXuYmAR8fl58qFS+wQz/AGgNUup91QWEkhNrBEXRP4mOCf04+9CoKaIiNCgkJl4AI70KkAztjHpQoALdiBQpiCi5yKFNCCmY5oUAf//Z";
+    beforeAll(function createManager(done) {
+      DatastoreManager().then(function(m) {
+        manager = m;
+        done();
+      });
+    });
 
-        beforeEach( function( done ) {
-          if (!localStore) {
-            DatastoreManager.deleteDatastore( DBName )
-                .then( function() {
-                    return DatastoreManager.openDatastore( DBName );
-                } )
-                .then( function(newLocalStore) {
-                  localStore = newLocalStore;
-                } )
-                .catch( function( error ) {
-                    console.error( error );
-                } )
-                .fin( done );
-              } else {
+    afterEach(function deleteDatastore(done) {
+      manager.deleteDatastore(DBName)
+        .then(function() {
+          return manager.deleteDatastore(EncryptedDBName);
+        })
+        .catch(function(error) {
+          console.error(error);
+        })
+        .fin(done);
+    });
+
+    beforeEach(function createDatastores(done) {
+      manager.openDatastore(DBName)
+        .then(function(newLocalStore) {
+          localStore = newLocalStore;
+          return manager.openDatastore(EncryptedDBName, validEncryptionOptions);
+        })
+        .then(function(newEncryptedLocalStore) {
+          encryptedStore = newEncryptedLocalStore;
+        }).catch(function(error) {
+          console.error(error);
+        }).fin(done);
+    });
+
+    function testCRUD(storeDescription) {
+      describe('CRUD with Attachments (' + storeDescription + ')', function() {
+
+        describe('Callbacks', function() {
+          var toddEmployee = {
+            firstName: 'Todd',
+            age: 50,
+            ageAdjustment: 10,
+            _attachments: {
+              face: {
+                contentType: 'image/jpeg',
+                data: todd_image,
+              },
+            },
+          };
+
+          it('creates a document revision', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
+
+            datastore.createDocumentFromRevision(toddEmployee, function(error, docRevision) {
+              expect(error).toBe(null);
+              expect(docRevision).not.toBe(null);
+              expect(docRevision._id).toBeDefined();
+              expect(docRevision._rev).toBeDefined();
+              expect(docRevision.firstName).toBe(toddEmployee.firstName);
+              expect(docRevision._attachments).toBeDefined();
+              expect(docRevision._attachments.face).toBeDefined();
+              expect(docRevision._attachments.face.data).toBe(todd_image);
+              done();
+            }); //End-datastore-save
+          });
+
+          it('updates a document revision', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
+
+            datastore.createDocumentFromRevision(toddEmployee, function(error, docRevision) {
+              expect(error).toBe(null);
+              expect(docRevision).not.toBe(null);
+              expect(docRevision._id).toBeDefined();
+              expect(docRevision._rev).toBeDefined();
+              expect(docRevision.firstName).toBe(toddEmployee.firstName);
+              expect(docRevision._attachments).toBeDefined();
+              expect(docRevision._attachments.face).toBeDefined();
+              expect(docRevision._attachments.face.data).toBe(todd_image);
+
+              // Update
+              var newFirstName = 'Steve';
+              docRevision.firstName = newFirstName;
+              docRevision._attachments.face.data = dillon_image;
+
+              datastore.updateDocumentFromRevision(docRevision, function(error, updatedRevision) {
+                expect(error).toBe(null);
+                expect(updatedRevision).not.toBe(null);
+                expect(updatedRevision._id).toBeDefined();
+                expect(updatedRevision._rev).toBeDefined();
+                expect(updatedRevision.firstName).toBe(newFirstName);
+                expect(updatedRevision._attachments).toBeDefined();
+                expect(updatedRevision._attachments.face).toBeDefined();
+                expect(updatedRevision._attachments.face.data).toBe(dillon_image);
+                done();
+              }); //End-update
+            }); //End-datastore-save
+          });
+
+          it('removes one attachment from an existing document revision', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
+
+            var toddMinion = {
+              firstName: 'Dillon',
+              age: 28,
+              ageAdjustment: 12,
+              _attachments: {
+                face: {
+                  contentType: 'image/jpeg',
+                  data: dillon_image,
+                },
+                idolFace: {
+                  contentType: 'image/jpeg',
+                  data: todd_image,
+                },
+              },
+            };
+
+            datastore.createDocumentFromRevision(toddMinion, function(error, docRevision) {
+              expect(error).toBe(null);
+              expect(docRevision).not.toBe(null);
+              expect(docRevision._id).toBeDefined();
+              expect(docRevision._rev).toBeDefined();
+              expect(docRevision.firstName).toBe(toddMinion.firstName);
+              expect(docRevision._attachments).toBeDefined();
+              expect(docRevision._attachments.face).toBeDefined();
+              expect(docRevision._attachments.face.data).toBe(dillon_image);
+              expect(docRevision._attachments.idolFace).toBeDefined();
+              expect(docRevision._attachments.idolFace.data).toBe(todd_image);
+
+              // Remove idolFace attachment
+              delete docRevision._attachments.idolFace;
+
+              datastore.updateDocumentFromRevision(docRevision, function(error, updatedRevision) {
+                expect(error).toBe(null);
+                expect(updatedRevision).not.toBe(null);
+                expect(updatedRevision._id).toBeDefined();
+                expect(updatedRevision._rev).toBeDefined();
+                expect(updatedRevision._attachments).toBeDefined();
+                expect(updatedRevision._attachments.face).toBeDefined();
+                expect(updatedRevision._attachments.face.data).toBe(dillon_image);
+                expect(updatedRevision._attachments.idolFace).not.toBeDefined();
+                done();
+              }); //End-update
+            }); //End-datastore-save
+          });
+
+          it('removes all attachments from an existing document revision', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
+
+            var toddMinion = {
+              firstName: 'Dillon',
+              age: 28,
+              ageAdjustment: 12,
+              _attachments: {
+                face: {
+                  contentType: 'image/jpeg',
+                  data: dillon_image,
+                },
+                idolFace: {
+                  contentType: 'image/jpeg',
+                  data: todd_image,
+                },
+              },
+            };
+
+            datastore.createDocumentFromRevision(toddMinion, function(error, docRevision) {
+              expect(error).toBe(null);
+              expect(docRevision).not.toBe(null);
+              expect(docRevision._id).toBeDefined();
+              expect(docRevision._rev).toBeDefined();
+              expect(docRevision.firstName).toBe(toddMinion.firstName);
+              expect(docRevision._attachments).toBeDefined();
+              expect(docRevision._attachments.face).toBeDefined();
+              expect(docRevision._attachments.face.data).toBe(dillon_image);
+              expect(docRevision._attachments.idolFace).toBeDefined();
+              expect(docRevision._attachments.idolFace.data).toBe(todd_image);
+
+              // Remove _attachments
+              delete docRevision._attachments;
+
+              datastore.updateDocumentFromRevision(docRevision, function(error, updatedRevision) {
+                expect(error).toBe(null);
+                expect(updatedRevision).not.toBe(null);
+                expect(updatedRevision._id).toBeDefined();
+                expect(updatedRevision._rev).toBeDefined();
+                expect(updatedRevision._attachments).not.toBeDefined();
+                done();
+              }); //End-update
+            }); //End-datastore-save
+          });
+
+          it('fetches a document revision by docId', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
+
+            // Save
+            datastore.createDocumentFromRevision(toddEmployee, function(error, docRevision) {
+              expect(error).toBe(null);
+              expect(docRevision).not.toBe(null);
+              expect(docRevision._id).toBeDefined();
+              expect(docRevision._rev).toBeDefined();
+              expect(docRevision.firstName).toBe(toddEmployee.firstName);
+              expect(docRevision._attachments).toBeDefined();
+              expect(docRevision._attachments.face).toBeDefined();
+              expect(docRevision._attachments.face.data).toBe(todd_image);
+
+              // GetDocument
+              datastore.getDocument(docRevision._id, function(error, fetchedRevision) {
+                expect(error).toBe(null);
+                expect(fetchedRevision).not.toBe(null);
+                expect(fetchedRevision._id).toBeDefined();
+                expect(fetchedRevision._rev).toBeDefined();
+                expect(fetchedRevision.firstName).toBe(toddEmployee.firstName);
+                expect(fetchedRevision._attachments).toBeDefined();
+                expect(fetchedRevision._attachments.face).toBeDefined();
+                expect(fetchedRevision._attachments.face.data).toBe(todd_image);
+                done();
+              }); //End-getDocument
+            }); //End-save
+          });
+
+          it('deletes a document revision', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
+
+            // Save
+            datastore.createDocumentFromRevision(toddEmployee, function(error, docRevision) {
+              expect(error).toBe(null);
+              expect(docRevision).not.toBe(null);
+              expect(docRevision._id).toBeDefined();
+              expect(docRevision._rev).toBeDefined();
+              expect(docRevision.firstName).toBe(toddEmployee.firstName);
+              expect(docRevision._attachments).toBeDefined();
+              expect(docRevision._attachments.face).toBeDefined();
+              expect(docRevision._attachments.face.data).toBe(todd_image);
+
+              // DeleteDocumentFromRevision
+              datastore.deleteDocumentFromRevision(docRevision, function(error, result) {
+                expect(error).toBe(null);
+                expect(result).not.toBe(null);
+                done();
+              }); //End-deleteDocumentFromRevision
+            }); //End-save
+          });
+
+          describe('Negative Tests', function() {
+            var toddRedefined = {
+              firstName: 'Todd',
+              age: 30,
+              _attachments: {
+                face: {
+                  contentType: 'image/jpeg',
+                  data: todd_image,
+                },
+              },
+            };
+
+
+            it('empty _attachments', function(done) {
+              var datastore = getDatastore(storeDescription);
+              expect(datastore).not.toBe(null);
+              var badAttachments = {};
+
+              toddRedefined._attachments = badAttachments;
+              try {
+                datastore.save(toddRedefined);
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
                 done();
               }
-        });
+            });
 
-        function testCRUD(storeDescription) {
-            describe('CRUD with Attachments (' + storeDescription + ')', function() {
+            it('empty face attachment', function(done) {
+              var datastore = getDatastore(storeDescription);
+              expect(datastore).not.toBe(null);
+              var badAttachments = {
+                face: {},
+              };
 
-                describe('Callbacks', function() {
-                    var toddEmployee = {
-                        "firstName": "Todd",
-                        "age": 50,
-                        "ageAdjustment": 10,
-                        "_attachments": {
-                            "face": {
-                                "contentType": "image/jpeg",
-                                "data": todd_image
-                            }
-                        }
-                    };
+              toddRedefined._attachments = badAttachments;
+              try {
+                datastore.save(toddRedefined);
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
 
-                    it("creates a document revision", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+            it('missing contentType', function(done) {
+              var datastore = getDatastore(storeDescription);
+              expect(datastore).not.toBe(null);
+              var badAttachments = {
+                face: {
+                  data: todd_image,
+                },
+              };
 
-                        datastore.createDocumentFromRevision(toddEmployee, function(error, docRevision) {
-                            expect(error).toBe(null);
-                            expect(docRevision).not.toBe(null);
-                            expect(docRevision._id).toBeDefined();
-                            expect(docRevision._rev).toBeDefined();
-                            expect(docRevision.firstName).toBe(toddEmployee.firstName);
-                            expect(docRevision._attachments).toBeDefined();
-                            expect(docRevision._attachments.face).toBeDefined();
-                            expect(docRevision._attachments.face.data).toBe(todd_image);
-                            done();
-                        }); //end-datastore-save
-                    });
+              toddRedefined._attachments = badAttachments;
+              try {
+                datastore.save(toddRedefined);
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+              //End-datastore-save
+            });
 
-                    it("updates a document revision", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+            it('missing data', function(done) {
+              var datastore = getDatastore(storeDescription);
+              expect(datastore).not.toBe(null);
+              var badAttachments = {
+                face: {
+                  contentType: 'image/jpeg',
+                },
+              };
 
-                        datastore.createDocumentFromRevision(toddEmployee, function(error, docRevision) {
-                            expect(error).toBe(null);
-                            expect(docRevision).not.toBe(null);
-                            expect(docRevision._id).toBeDefined();
-                            expect(docRevision._rev).toBeDefined();
-                            expect(docRevision.firstName).toBe(toddEmployee.firstName);
-                            expect(docRevision._attachments).toBeDefined();
-                            expect(docRevision._attachments.face).toBeDefined();
-                            expect(docRevision._attachments.face.data).toBe(todd_image);
+              toddRedefined._attachments = badAttachments;
+              try {
+                datastore.save(toddRedefined);
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+              //End-datastore-save
+            });
 
-                            // update
-                            var newFirstName = "Steve";
-                            docRevision.firstName = newFirstName;
-                            docRevision._attachments.face.data = dillon_image;
+          }); // End negative tests
 
-                            datastore.updateDocumentFromRevision(docRevision, function(error, updatedRevision) {
-                                expect(error).toBe(null);
-                                expect(updatedRevision).not.toBe(null);
-                                expect(updatedRevision._id).toBeDefined();
-                                expect(updatedRevision._rev).toBeDefined();
-                                expect(updatedRevision.firstName).toBe(newFirstName);
-                                expect(updatedRevision._attachments).toBeDefined();
-                                expect(updatedRevision._attachments.face).toBeDefined();
-                                expect(updatedRevision._attachments.face.data).toBe(dillon_image);
-                                done();
-                            }); //end-update
-                        }); //end-datastore-save
-                    });
+        }); // End-Callbacks-describe-block
 
-                    it('removes one attachment from an existing document revision', function(done){
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+        describe('Promises', function() {
+          var toddEmployee = {
+            firstName: 'Todd',
+            age: 50,
+            ageAdjustment: 10,
+            _attachments: {
+              face: {
+                contentType: 'image/jpeg',
+                data: todd_image,
+              },
+            },
+          };
 
-                        var toddMinion = {
-                            firstName: "Dillon",
-                            age: 28,
-                            ageAdjustment: 12,
-                            _attachments: {
-                                face: {
-                                    "contentType": "image/jpeg",
-                                    "data": dillon_image
-                                },
-                                idolFace: {
-                                    "contentType": "image/jpeg",
-                                    "data": todd_image
-                                }
-                            }
-                        };
+          it('creates a document revision', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        datastore.createDocumentFromRevision(toddMinion, function(error, docRevision) {
-                            expect(error).toBe(null);
-                            expect(docRevision).not.toBe(null);
-                            expect(docRevision._id).toBeDefined();
-                            expect(docRevision._rev).toBeDefined();
-                            expect(docRevision.firstName).toBe(toddMinion.firstName);
-                            expect(docRevision._attachments).toBeDefined();
-                            expect(docRevision._attachments.face).toBeDefined();
-                            expect(docRevision._attachments.face.data).toBe(dillon_image);
-                            expect(docRevision._attachments.idolFace).toBeDefined();
-                            expect(docRevision._attachments.idolFace.data).toBe(todd_image);
-
-                            // remove idolFace attachment
-                            delete docRevision._attachments.idolFace;
-
-                            datastore.updateDocumentFromRevision(docRevision, function(error, updatedRevision) {
-                                expect(error).toBe(null);
-                                expect(updatedRevision).not.toBe(null);
-                                expect(updatedRevision._id).toBeDefined();
-                                expect(updatedRevision._rev).toBeDefined();
-                                expect(updatedRevision._attachments).toBeDefined();
-                                expect(updatedRevision._attachments.face).toBeDefined();
-                                expect(updatedRevision._attachments.face.data).toBe(dillon_image);
-                                expect(updatedRevision._attachments.idolFace).not.toBeDefined();
-                                done();
-                            }); //end-update
-                        }); //end-datastore-save
-                    });
-
-                    it('removes all attachments from an existing document revision', function(done){
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
-
-                        var toddMinion = {
-                            firstName: "Dillon",
-                            age: 28,
-                            ageAdjustment: 12,
-                            _attachments: {
-                                face: {
-                                    "contentType": "image/jpeg",
-                                    "data": dillon_image
-                                },
-                                idolFace: {
-                                    "contentType": "image/jpeg",
-                                    "data": todd_image
-                                }
-                            }
-                        };
-
-                        datastore.createDocumentFromRevision(toddMinion, function(error, docRevision) {
-                            expect(error).toBe(null);
-                            expect(docRevision).not.toBe(null);
-                            expect(docRevision._id).toBeDefined();
-                            expect(docRevision._rev).toBeDefined();
-                            expect(docRevision.firstName).toBe(toddMinion.firstName);
-                            expect(docRevision._attachments).toBeDefined();
-                            expect(docRevision._attachments.face).toBeDefined();
-                            expect(docRevision._attachments.face.data).toBe(dillon_image);
-                            expect(docRevision._attachments.idolFace).toBeDefined();
-                            expect(docRevision._attachments.idolFace.data).toBe(todd_image);
-
-                            // remove _attachments
-                            delete docRevision._attachments;
-
-                            datastore.updateDocumentFromRevision(docRevision, function(error, updatedRevision) {
-                                expect(error).toBe(null);
-                                expect(updatedRevision).not.toBe(null);
-                                expect(updatedRevision._id).toBeDefined();
-                                expect(updatedRevision._rev).toBeDefined();
-                                expect(updatedRevision._attachments).not.toBeDefined();
-                                done();
-                            }); //end-update
-                        }); //end-datastore-save
-                    });
-
-                    it("fetches a document revision by docId", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
-
-                        // save
-                        datastore.createDocumentFromRevision(toddEmployee, function(error, docRevision) {
-                            expect(error).toBe(null);
-                            expect(docRevision).not.toBe(null);
-                            expect(docRevision._id).toBeDefined();
-                            expect(docRevision._rev).toBeDefined();
-                            expect(docRevision.firstName).toBe(toddEmployee.firstName);
-                            expect(docRevision._attachments).toBeDefined();
-                            expect(docRevision._attachments.face).toBeDefined();
-                            expect(docRevision._attachments.face.data).toBe(todd_image);
-
-                            // getDocument
-                            datastore.getDocument(docRevision._id, function(error, fetchedRevision) {
-                                expect(error).toBe(null);
-                                expect(fetchedRevision).not.toBe(null);
-                                expect(fetchedRevision._id).toBeDefined();
-                                expect(fetchedRevision._rev).toBeDefined();
-                                expect(fetchedRevision.firstName).toBe(toddEmployee.firstName);
-                                expect(fetchedRevision._attachments).toBeDefined();
-                                expect(fetchedRevision._attachments.face).toBeDefined();
-                                expect(fetchedRevision._attachments.face.data).toBe(todd_image);
-                                done();
-                            }); //end-getDocument
-                        }); //end-save
-                    });
-
-                    it("deletes a document revision", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
-
-                        // save
-                        datastore.createDocumentFromRevision(toddEmployee, function(error, docRevision) {
-                            expect(error).toBe(null);
-                            expect(docRevision).not.toBe(null);
-                            expect(docRevision._id).toBeDefined();
-                            expect(docRevision._rev).toBeDefined();
-                            expect(docRevision.firstName).toBe(toddEmployee.firstName);
-                            expect(docRevision._attachments).toBeDefined();
-                            expect(docRevision._attachments.face).toBeDefined();
-                            expect(docRevision._attachments.face.data).toBe(todd_image);
-
-                            // deleteDocumentFromRevision
-                            datastore.deleteDocumentFromRevision(docRevision, function(error, result) {
-                                expect(error).toBe(null);
-                                expect(result).not.toBe(null);
-                                done();
-                            }); //end-deleteDocumentFromRevision
-                        }); //end-save
-                    });
-
-                    describe('Negative Tests', function() {
-                        var toddRedefined = {
-                            "firstName": "Todd",
-                            "age": 30,
-                            "_attachments": {
-                                "face": {
-                                    "contentType": "image/jpeg",
-                                    "data": todd_image
-                                }
-                            }
-                        };
-
-
-                        it("empty _attachments", function(done) {
-                            var datastore = getDatastore(storeDescription);
-                            expect(datastore).not.toBe(null);
-                            var badAttachments = {};
-
-                            toddRedefined._attachments = badAttachments;
-                            try {
-                                datastore.save(toddRedefined);
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
-
-                        it("empty face attachment", function(done) {
-                            var datastore = getDatastore(storeDescription);
-                            expect(datastore).not.toBe(null);
-                            var badAttachments = {
-                                "face": {}
-                            };
-
-                            toddRedefined._attachments = badAttachments;
-                            try {
-                                datastore.save(toddRedefined);
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
-
-                        it("missing contentType", function(done) {
-                            var datastore = getDatastore(storeDescription);
-                            expect(datastore).not.toBe(null);
-                            var badAttachments = {
-                                "face": {
-                                    "data": todd_image
-                                }
-                            };
-
-                            toddRedefined._attachments = badAttachments;
-                            try {
-                                datastore.save(toddRedefined);
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                            //end-datastore-save
-                        });
-
-                        it("missing data", function(done) {
-                            var datastore = getDatastore(storeDescription);
-                            expect(datastore).not.toBe(null);
-                            var badAttachments = {
-                                "face": {
-                                    "contentType": "image/jpeg"
-                                }
-                            };
-
-                            toddRedefined._attachments = badAttachments;
-                            try {
-                                datastore.save(toddRedefined);
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                            //end-datastore-save
-                        });
-
-                    }); // end negative tests
-
-                }); // end-Callbacks-describe-block
-
-                describe('Promises', function() {
-                    var toddEmployee = {
-                        "firstName": "Todd",
-                        "age": 50,
-                        "ageAdjustment": 10,
-                        "_attachments": {
-                            "face": {
-                                "contentType": "image/jpeg",
-                                "data": todd_image
-                            }
-                        }
-                    };
-
-                    it("creates a document revision", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
-
-                        datastore.createDocumentFromRevision(toddEmployee)
+            datastore.createDocumentFromRevision(toddEmployee)
                             .then(function(docRevision) {
-                                expect(docRevision).not.toBe(null);
-                                expect(docRevision._id).toBeDefined();
-                                expect(docRevision._rev).toBeDefined();
-                                expect(docRevision.firstName).toBe(toddEmployee.firstName);
-                                expect(docRevision._attachments).toBeDefined();
-                                expect(docRevision._attachments.face).toBeDefined();
-                                expect(docRevision._attachments.face.data).toBe(todd_image);
+                              expect(docRevision).not.toBe(null);
+                              expect(docRevision._id).toBeDefined();
+                              expect(docRevision._rev).toBeDefined();
+                              expect(docRevision.firstName).toBe(toddEmployee.firstName);
+                              expect(docRevision._attachments).toBeDefined();
+                              expect(docRevision._attachments.face).toBeDefined();
+                              expect(docRevision._attachments.face.data).toBe(todd_image);
                             })
                             .catch(function(error) {
-                                expect(error).toBe(null);
+                              expect(error).toBe(null);
                             })
                             .fin(done);
-                    });
+          });
 
 
-                    it("updates a saved document revision", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('updates a saved document revision', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        // update
-                        var newFirstName = "Steve";
+            // Update
+            var newFirstName = 'Steve';
 
-                        datastore.createDocumentFromRevision(toddEmployee)
+            datastore.createDocumentFromRevision(toddEmployee)
                             .then(function(docRevision) {
-                                expect(docRevision).not.toBe(null);
-                                expect(docRevision._id).toBeDefined();
-                                expect(docRevision._rev).toBeDefined();
-                                expect(docRevision.firstName).toBe(toddEmployee.firstName);
-                                expect(docRevision._attachments).toBeDefined();
-                                expect(docRevision._attachments.face).toBeDefined();
-                                expect(docRevision._attachments.face.data).toBe(todd_image);
+                              expect(docRevision).not.toBe(null);
+                              expect(docRevision._id).toBeDefined();
+                              expect(docRevision._rev).toBeDefined();
+                              expect(docRevision.firstName).toBe(toddEmployee.firstName);
+                              expect(docRevision._attachments).toBeDefined();
+                              expect(docRevision._attachments.face).toBeDefined();
+                              expect(docRevision._attachments.face.data).toBe(todd_image);
 
-                                docRevision.firstName = newFirstName;
-                                docRevision._attachments.face.data = dillon_image;
+                              docRevision.firstName = newFirstName;
+                              docRevision._attachments.face.data = dillon_image;
 
-                                return datastore.updateDocumentFromRevision(docRevision);
+                              return datastore.updateDocumentFromRevision(docRevision);
                             })
                             .then(function(updatedRevision) {
-                                expect(updatedRevision).not.toBe(null);
-                                expect(updatedRevision._id).toBeDefined();
-                                expect(updatedRevision._rev).toBeDefined();
-                                expect(updatedRevision.firstName).toBe(newFirstName);
-                                expect(updatedRevision._attachments).toBeDefined();
-                                expect(updatedRevision._attachments.face).toBeDefined();
-                                expect(updatedRevision._attachments.face.data).toBe(dillon_image);
+                              expect(updatedRevision).not.toBe(null);
+                              expect(updatedRevision._id).toBeDefined();
+                              expect(updatedRevision._rev).toBeDefined();
+                              expect(updatedRevision.firstName).toBe(newFirstName);
+                              expect(updatedRevision._attachments).toBeDefined();
+                              expect(updatedRevision._attachments.face).toBeDefined();
+                              expect(updatedRevision._attachments.face.data).toBe(dillon_image);
                             })
                             .catch(function(error) {
-                                expect(error).toBe(null);
+                              expect(error).toBe(null);
                             })
                             .fin(done);
-                    });
+          });
 
-                    it("fetches a document revision by docId", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('fetches a document revision by docId', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        // save
-                        datastore.createDocumentFromRevision(toddEmployee)
+            // Save
+            datastore.createDocumentFromRevision(toddEmployee)
                             .then(function(docRevision) {
-                                expect(docRevision).not.toBe(null);
-                                expect(docRevision._id).toBeDefined();
-                                expect(docRevision._rev).toBeDefined();
-                                expect(docRevision.firstName).toBe(toddEmployee.firstName);
-                                expect(docRevision._attachments).toBeDefined();
-                                expect(docRevision._attachments.face).toBeDefined();
-                                expect(docRevision._attachments.face.data).toBe(todd_image);
+                              expect(docRevision).not.toBe(null);
+                              expect(docRevision._id).toBeDefined();
+                              expect(docRevision._rev).toBeDefined();
+                              expect(docRevision.firstName).toBe(toddEmployee.firstName);
+                              expect(docRevision._attachments).toBeDefined();
+                              expect(docRevision._attachments.face).toBeDefined();
+                              expect(docRevision._attachments.face.data).toBe(todd_image);
 
-                                // getDocument
-                                return datastore.getDocument(docRevision._id);
+                              // GetDocument
+                              return datastore.getDocument(docRevision._id);
                             })
                             .then(function(fetchedRevision) {
-                                expect(fetchedRevision).not.toBe(null);
-                                expect(fetchedRevision._id).toBeDefined();
-                                expect(fetchedRevision._rev).toBeDefined();
-                                expect(fetchedRevision.firstName).toBe(toddEmployee.firstName);
-                                expect(fetchedRevision._attachments).toBeDefined();
-                                expect(fetchedRevision._attachments.face).toBeDefined();
-                                expect(fetchedRevision._attachments.face.data).toBe(todd_image);
+                              expect(fetchedRevision).not.toBe(null);
+                              expect(fetchedRevision._id).toBeDefined();
+                              expect(fetchedRevision._rev).toBeDefined();
+                              expect(fetchedRevision.firstName).toBe(toddEmployee.firstName);
+                              expect(fetchedRevision._attachments).toBeDefined();
+                              expect(fetchedRevision._attachments.face).toBeDefined();
+                              expect(fetchedRevision._attachments.face.data).toBe(todd_image);
                             })
                             .catch(function(error) {
-                                expect(error).toBe(null);
+                              expect(error).toBe(null);
                             })
                             .fin(done);
-                    });
+          });
 
-                    it("deletes a document revision", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('deletes a document revision', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        // save
-                        datastore.createDocumentFromRevision(toddEmployee)
+            // Save
+            datastore.createDocumentFromRevision(toddEmployee)
                             .then(function(docRevision) {
-                                expect(docRevision).not.toBe(null);
-                                expect(docRevision._id).toBeDefined();
-                                expect(docRevision._rev).toBeDefined();
-                                expect(docRevision.firstName).toBe(toddEmployee.firstName);
-                                expect(docRevision._attachments).toBeDefined();
-                                expect(docRevision._attachments.face).toBeDefined();
-                                expect(docRevision._attachments.face.data).toBe(todd_image);
+                              expect(docRevision).not.toBe(null);
+                              expect(docRevision._id).toBeDefined();
+                              expect(docRevision._rev).toBeDefined();
+                              expect(docRevision.firstName).toBe(toddEmployee.firstName);
+                              expect(docRevision._attachments).toBeDefined();
+                              expect(docRevision._attachments.face).toBeDefined();
+                              expect(docRevision._attachments.face.data).toBe(todd_image);
 
-                                // deleteDocumentFromRevision
-                                return datastore.deleteDocumentFromRevision(docRevision);
+                              // DeleteDocumentFromRevision
+                              return datastore.deleteDocumentFromRevision(docRevision);
                             })
                             .then(function(result) {
-                                expect(result).not.toBe(null);
+                              expect(result).not.toBe(null);
                             })
                             .catch(function(error) {
-                                expect(error).not.toBe(null);
+                              expect(error).not.toBe(null);
                             })
                             .fin(done);
-                    });
+          });
 
-                    describe('Negative Tests', function() {
-                        var toddRedefined = {
-                            "firstName": "Todd",
-                            "age": 30,
-                            "_attachments": {
-                                "face": {
-                                    "contentType": "image/jpeg",
-                                    "data": todd_image
-                                }
-                            }
-                        };
+          describe('Negative Tests', function() {
+            var toddRedefined = {
+              firstName: 'Todd',
+              age: 30,
+              _attachments: {
+                face: {
+                  contentType: 'image/jpeg',
+                  data: todd_image,
+                },
+              },
+            };
 
 
-                        it("empty _attachments", function(done) {
-                            var datastore = getDatastore(storeDescription);
-                            expect(datastore).not.toBe(null);
+            it('empty _attachments', function(done) {
+              var datastore = getDatastore(storeDescription);
+              expect(datastore).not.toBe(null);
 
-                            var badAttachments = {};
+              var badAttachments = {};
 
-                            toddRedefined._attachments = badAttachments;
-                            try {
-                                datastore.save(toddRedefined)
+              toddRedefined._attachments = badAttachments;
+              try {
+                datastore.save(toddRedefined)
                                     .then(function() {
-                                        expect(true).toBe(false);
+                                      expect(true).toBe(false);
                                     })
                                     .catch(function(error) {
-                                        expect(true).toBe(false);
+                                      expect(true).toBe(false);
                                     });
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
-
-                        it("empty face attachment", function(done) {
-                            var datastore = getDatastore(storeDescription);
-                            expect(datastore).not.toBe(null);
-                            var badAttachments = {
-                                "face": {}
-                            };
-
-                            toddRedefined._attachments = badAttachments;
-                            try {
-                                datastore.save(toddRedefined)
-                                    .then(function() {
-                                        expect(true).toBe(false);
-                                    })
-                                    .catch(function(error) {
-                                        expect(true).toBe(false);
-                                    });
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
-
-                        it("missing contentType", function(done) {
-                            var datastore = getDatastore(storeDescription);
-                            expect(datastore).not.toBe(null);
-                            var badAttachments = {
-                                "face": {
-                                    "data": todd_image
-                                }
-                            };
-
-                            toddRedefined._attachments = badAttachments;
-                            try {
-                                datastore.save(toddRedefined)
-                                    .then(function() {
-                                        expect(true).toBe(false);
-                                    })
-                                    .catch(function(error) {
-                                        expect(true).toBe(false);
-                                    });
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
-
-                        it("missing data", function(done) {
-                            var datastore = getDatastore(storeDescription);
-                            expect(datastore).not.toBe(null);
-                            var badAttachments = {
-                                "face": {
-                                    "contentType": "image/jpeg"
-                                }
-                            };
-
-                            toddRedefined._attachments = badAttachments;
-                            try {
-                                datastore.save(toddRedefined)
-                                    .then(function() {
-                                        expect(true).toBe(false);
-                                    })
-                                    .catch(function(error) {
-                                        expect(true).toBe(false);
-                                    });
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
-                    }); // end negative tests
-                }); // end-Promises-describe-block
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
             });
-        }
 
-        function testQuery(storeDescription) {
+            it('empty face attachment', function(done) {
+              var datastore = getDatastore(storeDescription);
+              expect(datastore).not.toBe(null);
+              var badAttachments = {
+                face: {},
+              };
 
-            var indexName = 'ageIndex';
-            var ageKey = 'age';
-            var nameKey = 'name';
-            var nameValue = 'Dillon';
-            var faceKey = 'face';
-            var idolKey = 'idolFace';
+              toddRedefined._attachments = badAttachments;
+              try {
+                datastore.save(toddRedefined)
+                                    .then(function() {
+                                      expect(true).toBe(false);
+                                    })
+                                    .catch(function(error) {
+                                      expect(true).toBe(false);
+                                    });
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
 
-            var fieldNames = [ageKey];
+            it('missing contentType', function(done) {
+              var datastore = getDatastore(storeDescription);
+              expect(datastore).not.toBe(null);
+              var badAttachments = {
+                face: {
+                  data: todd_image,
+                },
+              };
 
-            describe('Query with Attachments (' + storeDescription + ')', function() {
-                beforeEach(function(done) {
-                    var datastore = getDatastore(storeDescription);
-                    expect(datastore).not.toBe(null);
+              toddRedefined._attachments = badAttachments;
+              try {
+                datastore.save(toddRedefined)
+                                    .then(function() {
+                                      expect(true).toBe(false);
+                                    })
+                                    .catch(function(error) {
+                                      expect(true).toBe(false);
+                                    });
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
 
-                    datastore.ensureIndexed(fieldNames, indexName)
+            it('missing data', function(done) {
+              var datastore = getDatastore(storeDescription);
+              expect(datastore).not.toBe(null);
+              var badAttachments = {
+                face: {
+                  contentType: 'image/jpeg',
+                },
+              };
+
+              toddRedefined._attachments = badAttachments;
+              try {
+                datastore.save(toddRedefined)
+                                    .then(function() {
+                                      expect(true).toBe(false);
+                                    })
+                                    .catch(function(error) {
+                                      expect(true).toBe(false);
+                                    });
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
+          }); // End negative tests
+        }); // End-Promises-describe-block
+      });
+    }
+
+    function testQuery(storeDescription) {
+
+      var indexName = 'ageIndex';
+      var ageKey = 'age';
+      var nameKey = 'name';
+      var nameValue = 'Dillon';
+      var faceKey = 'face';
+      var idolKey = 'idolFace';
+
+      var fieldNames = [ageKey];
+
+      describe('Query with Attachments (' + storeDescription + ')', function() {
+        beforeEach(function(done) {
+          var datastore = getDatastore(storeDescription);
+          expect(datastore).not.toBe(null);
+
+          datastore.ensureIndexed(fieldNames, indexName)
                         .then(function() {
-                            return setupQueryTests(0, 5, datastore);
+                          return setupQueryTests(0, 5, datastore);
                         })
                         .then(function() {
-                            return setupQueryTests(5, 10, datastore);
+                          return setupQueryTests(5, 10, datastore);
                         })
                         .then(function() {
-                            return setupQueryTests(10, 15, datastore);
+                          return setupQueryTests(10, 15, datastore);
                         })
                         .then(function() {
-                            return setupQueryTests(15, 20, datastore);
+                          return setupQueryTests(15, 20, datastore);
                         })
                         .catch(function(error) {
-                            expect(error).toBe(null);
+                          expect(error).toBe(null);
                         })
                         .fin(done);
-                });
+        });
 
-                describe('Callbacks', function() {
-                    it('should perform a query for equality', function(done) {
-                        var query = {
-                            selector: {
-                                age: {
-                                    $eq: 5
-                                }
-                            }
-                        };
+        describe('Callbacks', function() {
+          it('should perform a query for equality', function(done) {
+            var query = {
+              selector: {
+                age: {
+                  $eq: 5,
+                },
+              },
+            };
 
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        datastore.find(query,
+            datastore.find(query,
                             function(err, results) {
-                                expect(err).toBe(null);
-                                expect(results).not.toBe(null);
+                              expect(err).toBe(null);
+                              expect(results).not.toBe(null);
 
-                                results.forEach(function (result) {
+                              results.forEach(function(result) {
                                   expect(result[ageKey]).toBe(5);
                                   expect(result[nameKey]).toBe(nameValue + 5);
                                   expect(result._attachments).toBeDefined();
@@ -671,30 +684,30 @@ exports.defineAutoTests = function() {
                                   expect(result._attachments.idolFace.data).toBe(todd_image);
                                 });
 
-                                done();
+                              done();
                             });
-                    });
+          });
 
-                }); // End Callback Tests
+        }); // End Callback Tests
 
-                describe('Promises', function() {
-                    it('should perform a query for equality', function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+        describe('Promises', function() {
+          it('should perform a query for equality', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        var query = {
-                            selector: {
-                                age: {
-                                    $eq: 5
-                                }
-                            }
-                        };
+            var query = {
+              selector: {
+                age: {
+                  $eq: 5,
+                },
+              },
+            };
 
-                        datastore.find(query)
+            datastore.find(query)
                             .then(function(results) {
-                                expect(results).not.toBe(null);
+                              expect(results).not.toBe(null);
 
-                                results.forEach(function (result) {
+                              results.forEach(function(result) {
                                   expect(result[ageKey]).toBe(5);
                                   expect(result[nameKey]).toBe(nameValue + 5);
                                   expect(result._attachments).toBeDefined();
@@ -705,43 +718,43 @@ exports.defineAutoTests = function() {
                                 });
                             })
                             .catch(function(error) {
-                                expect(true).toBe(false);
+                              expect(true).toBe(false);
                             })
                             .fin(done);
-                    });
-                }); // End Promise Tests
-            });
+          });
+        }); // End Promise Tests
+      });
 
-            function setupQueryTests(start, end, datastore) {
-                var promises = [];
-                for (var i = start; i < end; i++) {
-                    var toddMinion = {
-                        name: nameValue + i,
-                        age: i,
-                        "_attachments": {
-                            face: {
-                                "contentType": "image/jpeg",
-                                "data": dillon_image
-                            },
-                            idolFace: {
-                                "contentType": "image/jpeg",
-                                "data": todd_image
-                            }
-                        }
-                    };
-                    promises.push(datastore.createDocumentFromRevision(toddMinion));
-                }
-
-                return Q.all(promises);
-            }
+      function setupQueryTests(start, end, datastore) {
+        var promises = [];
+        for (var i = start; i < end; i++) {
+          var toddMinion = {
+            name: nameValue + i,
+            age: i,
+            _attachments: {
+              face: {
+                contentType: 'image/jpeg',
+                data: dillon_image,
+              },
+              idolFace: {
+                contentType: 'image/jpeg',
+                data: todd_image,
+              },
+            },
+          };
+          promises.push(datastore.createDocumentFromRevision(toddMinion));
         }
 
-        testCRUD("local");
+        return Q.all(promises);
+      }
+    }
 
-        testQuery("local");
+    testCRUD('local');
 
-        function getDatastore(storeDescription){
-            return localStore;
-        }
-    });
+    testQuery('local');
+
+    function getDatastore(storeDescription) {
+      return localStore;
+    }
+  });
 };

--- a/tests/CRUDTests.js
+++ b/tests/CRUDTests.js
@@ -13,642 +13,678 @@
  *
  */
 
-var DatastoreManager = require( 'cloudant-sync.DatastoreManager' );
-var DBName = "cruddb";
+var DatastoreManager = require('cloudant-sync.DatastoreManager').DatastoreManager;
+var DBName = 'cruddb';
+var EncryptedDBName = DBName + 'secure';
 exports.defineAutoTests = function() {
-    describe( 'Datastore', function() {
+  describe('Datastore', function() {
 
-        var validEncryptionOptions = {
-            password: 'passw0rd',
-            identifier: 'toolkit'
-        };
+    var validEncryptionOptions = {
+      password: 'passw0rd',
+      identifier: 'toolkit',
+    };
 
-        var localStore = null;
 
-        var storeName = null;
+    var manager;
+    var localStore = null;
+    var encryptedStore = null;
 
-        function getDatastore( datastoreDescription ) {
-            return localStore;
-        }
+    var storeName = null;
+    var encryptedStoreName = null;
 
-        beforeEach( function( done ) {
+    beforeAll(function createManager(done) {
+      DatastoreManager().then(function(m) {
+        manager = m;
+        done();
+      });
+    });
+
+    afterEach(function deleteDatastore(done) {
+      manager.deleteDatastore(DBName)
+        .then(function() {
+          return manager.deleteDatastore(EncryptedDBName);
+        })
+        .catch(function(error) {
+          console.error(error);
+        })
+        .fin(done);
+    });
+
+    beforeEach(function createDatastores(done) {
+      manager.openDatastore(DBName)
+        .then(function(newLocalStore) {
+          localStore = newLocalStore;
+          return manager.openDatastore(EncryptedDBName, validEncryptionOptions);
+        })
+        .then(function(newEncryptedLocalStore) {
+          encryptedStore = newEncryptedLocalStore;
+        }).catch(function(error) {
+          console.error(error);
+        }).fin(done);
+    });
+
+    function getDatastore( datastoreDescription ) {
+      return localStore;
+    }
+
+    beforeEach(function(done) {
           if (!localStore) {
-            DatastoreManager.deleteDatastore( DBName )
-                .then( function() {
-                    return DatastoreManager.openDatastore( DBName );
-                } )
-                .then( function(newLocalStore) {
+            DatastoreManager.deleteDatastore(DBName)
+                .then(function() {
+                  return DatastoreManager.openDatastore(DBName);
+                })
+                .then(function(newLocalStore) {
                   localStore = newLocalStore;
                 })
-                .catch( function( error ) {
-                    console.error( error );
-                } )
-                .fin( done );
-              } else {
+                .catch(function(error) {
+                  console.error(error);
+                })
+                .fin(done);
+          } else {
+            done();
+          }
+        });
+
+    function testCRUD(datastoreDescription) {
+
+      describe('CRUD (' + datastoreDescription + ')', function() {
+
+        it('.createDocumentFromRevision exists', function() {
+          var datastore = getDatastore(datastoreDescription);
+          expect(datastore).not.toBe(null);
+          expect(datastore.updateDocumentFromRevision).toBeDefined();
+        });
+
+        it('.updateDocumentFromRevision exists', function() {
+          var datastore = getDatastore(datastoreDescription);
+          expect(datastore).not.toBe(null);
+          expect(datastore.updateDocumentFromRevision).toBeDefined();
+        });
+
+        it('.getDocument exists', function() {
+          var datastore = getDatastore(datastoreDescription);
+          expect(datastore).not.toBe(null);
+          expect(datastore.getDocument).toBeDefined();
+        });
+
+        it('.deleteDocumentFromRevision exists', function() {
+          var datastore = getDatastore(datastoreDescription);
+          expect(datastore).not.toBe(null);
+          expect(datastore.deleteDocumentFromRevision).toBeDefined();
+        });
+
+        describe('Callbacks', function() {
+          var employee = {
+            firstName: 'Todd',
+            lastName: 'Kaplinger',
+            numberOne: 1,
+            numberFive: 5,
+          };
+
+          var objWithoutBody = {};
+
+          it('creates a document revision', function(done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
+
+            datastore.createDocumentFromRevision(employee, function(error, docRevision) {
+              expect(error).toBe(null);
+              expect(docRevision).not.toBe(null);
+              expect(docRevision._id).toBeDefined();
+              expect(docRevision._rev).toBeDefined();
+              expect(docRevision.firstName).toBe(employee.firstName);
+              expect(docRevision.lastName).toBe(employee.lastName);
+              done();
+            }); //End-datastore-updateDocumentFromRevision
+          });
+
+          it('updates a document revision', function(done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
+
+            datastore.createDocumentFromRevision(employee, function(error, docRevision) {
+              expect(error).toBe(null);
+              expect(docRevision).not.toBe(null);
+              expect(docRevision._id).toBeDefined();
+              expect(docRevision._rev).toBeDefined();
+              expect(docRevision.firstName).toBe(employee.firstName);
+              expect(docRevision.lastName).toBe(employee.lastName);
+
+              // Update
+              var newFirstName = 'Steve';
+              docRevision.firstName = newFirstName;
+
+              datastore.updateDocumentFromRevision(docRevision, function(error,
+                  updatedRevision) {
+                expect(error).toBe(null);
+                expect(updatedRevision).not.toBe(
+                    null);
+                expect(updatedRevision._id).toBeDefined();
+                expect(updatedRevision._rev).toBeDefined();
+                expect(updatedRevision.firstName)
+                    .toBe(newFirstName);
                 done();
-              }
-        } );
+              }); //End-update
+            }); //End-datastore-updateDocumentFromRevision
+          });
 
-        function testCRUD( datastoreDescription ) {
+          it('finds a document revision by docId', function(done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
 
-            describe( 'CRUD (' + datastoreDescription + ')', function() {
+            // Create
+            datastore.createDocumentFromRevision(employee, function(error, docRevision) {
+              expect(error).toBe(null);
+              expect(docRevision).not.toBe(null);
+              expect(docRevision._id).toBeDefined();
+              expect(docRevision._rev).toBeDefined();
+              expect(docRevision.firstName).toBe(employee.firstName);
 
-                it( '.createDocumentFromRevision exists', function() {
-                    var datastore = getDatastore( datastoreDescription );
-                    expect( datastore ).not.toBe( null );
-                    expect( datastore.updateDocumentFromRevision ).toBeDefined();
-                } );
+              // GetDocument
+              datastore.getDocument(docRevision._id, function(
+                  error, fetchedRevision) {
+                expect(error).toBe(null);
+                expect(fetchedRevision).not.toBe(
+                    null);
+                expect(fetchedRevision._id).toBeDefined();
+                expect(fetchedRevision._rev).toBeDefined();
+                expect(fetchedRevision.firstName)
+                    .toBe(employee.firstName);
+                done();
+              }); //End-getDocument
+            }); //End-create
+          });
 
-                it( '.updateDocumentFromRevision exists', function() {
-                    var datastore = getDatastore( datastoreDescription );
-                    expect( datastore ).not.toBe( null );
-                    expect( datastore.updateDocumentFromRevision ).toBeDefined();
-                } );
+          it('deletes a document revision', function(done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
 
-                it( '.getDocument exists', function() {
-                    var datastore = getDatastore( datastoreDescription );
-                    expect( datastore ).not.toBe( null );
-                    expect( datastore.getDocument ).toBeDefined();
-                } );
+            // Create
+            datastore.createDocumentFromRevision(employee, function(error, docRevision) {
+              expect(error).toBe(null);
+              expect(docRevision).not.toBe(null);
+              expect(docRevision._id).toBeDefined();
+              expect(docRevision._rev).toBeDefined();
+              expect(docRevision.firstName).toBe(employee.firstName);
 
-                it( '.deleteDocumentFromRevision exists', function() {
-                    var datastore = getDatastore( datastoreDescription );
-                    expect( datastore ).not.toBe( null );
-                    expect( datastore.deleteDocumentFromRevision ).toBeDefined();
-                } );
+              // DeleteDocumentFromRevision
+              datastore.deleteDocumentFromRevision(docRevision, function(error,
+                  result) {
+                expect(error).toBe(null);
+                expect(result).not.toBe(null);
+                expect(result._id).toBe(
+                    docRevision._id);
+                expect(result._rev).not.toBe(
+                    docRevision._rev);
+                expect(result._deleted).toBe(
+                    true);
+                done();
+              }); //End-deleteDocumentFromRevision
+            }); //End-create
+          });
 
-                describe( 'Callbacks', function() {
-                    var employee = {
-                        "firstName": "Todd",
-                        "lastName": "Kaplinger",
-                        "numberOne": 1,
-                        "numberFive": 5
-                    };
+          // Negative tests
+          it('returns error if doc revision is null', function(done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
 
-                    var objWithoutBody = {};
+            // Datastore-updateDocumentFromRevision
+            try {
+              datastore.createDocumentFromRevision(null);
+              expect(true).toBe(false);
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            } //End-datastore-updateDocumentFromRevision
+          });
 
-                    it( "creates a document revision", function( done ) {
-                        var datastore = getDatastore( datastoreDescription );
-                        expect( datastore ).not.toBe( null );
+          it('returns error if doc revision is wrong datatype', function(
+              done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
 
-                        datastore.createDocumentFromRevision( employee, function( error, docRevision ) {
-                            expect( error ).toBe( null );
-                            expect( docRevision ).not.toBe( null );
-                            expect( docRevision._id ).toBeDefined();
-                            expect( docRevision._rev ).toBeDefined();
-                            expect( docRevision.firstName ).toBe( employee.firstName );
-                            expect( docRevision.lastName ).toBe( employee.lastName );
-                            done();
-                        } ); //end-datastore-updateDocumentFromRevision
-                    } );
+            // Datastore-updateDocumentFromRevision
+            try {
+              datastore.createDocumentFromRevision([ 'foo' ]);
+              expect(true).toBe(false);
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            } //End-datastore-updateDocumentFromRevision
+          });
 
-                    it( "updates a document revision", function( done ) {
-                        var datastore = getDatastore( datastoreDescription );
-                        expect( datastore ).not.toBe( null );
+          it('createDocumentFromRevision without body is valid', function(done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
 
-                        datastore.createDocumentFromRevision( employee, function( error, docRevision ) {
-                            expect( error ).toBe( null );
-                            expect( docRevision ).not.toBe( null );
-                            expect( docRevision._id ).toBeDefined();
-                            expect( docRevision._rev ).toBeDefined();
-                            expect( docRevision.firstName ).toBe( employee.firstName );
-                            expect( docRevision.lastName ).toBe( employee.lastName );
+            // Datastore-updateDocumentFromRevision
+            datastore.createDocumentFromRevision(objWithoutBody, function(error, docRevision) {
+              expect(error).toBe(null);
+              expect(docRevision).not.toBe(null);
+              done();
+            }); //End-datastore-updateDocumentFromRevision
+          });
 
-                            // update
-                            var newFirstName = "Steve";
-                            docRevision.firstName = newFirstName;
+          it('returns error if only rev field set', function(done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
 
-                            datastore.updateDocumentFromRevision( docRevision, function( error,
-                                updatedRevision ) {
-                                expect( error ).toBe( null );
-                                expect( updatedRevision ).not.toBe(
-                                    null );
-                                expect( updatedRevision._id ).toBeDefined();
-                                expect( updatedRevision._rev ).toBeDefined();
-                                expect( updatedRevision.firstName )
-                                    .toBe( newFirstName );
-                                done();
-                            } ); //end-update
-                        } ); //end-datastore-updateDocumentFromRevision
-                    } );
+            employee._rev = 'some-revision';
 
-                    it( "finds a document revision by docId", function( done ) {
-                        var datastore = getDatastore( datastoreDescription );
-                        expect( datastore ).not.toBe( null );
+            // Datastore-updateDocumentFromRevision
+            try {
+              datastore.updateDocumentFromRevision(employee, function(error, docRevision) {
+                expect(true).toBe(false);
+              });
+              expect(true).toBe(false);
+            } catch (e) {
+              expect(e).not.toBe(null);
+              done();
+            }
+            //End-datastore-updateDocumentFromRevision
+          });
 
-                        // create
-                        datastore.createDocumentFromRevision( employee, function( error, docRevision ) {
-                            expect( error ).toBe( null );
-                            expect( docRevision ).not.toBe( null );
-                            expect( docRevision._id ).toBeDefined();
-                            expect( docRevision._rev ).toBeDefined();
-                            expect( docRevision.firstName ).toBe( employee.firstName );
+          it('returns error fetching a null document revision ID', function(
+              done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
 
-                            // getDocument
-                            datastore.getDocument( docRevision._id, function(
-                                error, fetchedRevision ) {
-                                expect( error ).toBe( null );
-                                expect( fetchedRevision ).not.toBe(
-                                    null );
-                                expect( fetchedRevision._id ).toBeDefined();
-                                expect( fetchedRevision._rev ).toBeDefined();
-                                expect( fetchedRevision.firstName )
-                                    .toBe( employee.firstName );
-                                done();
-                            } ); //end-getDocument
-                        } ); //end-create
-                    } );
+            try {
+              datastore.getDocument(null);
+              expect(true).toBe(false);
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it( "deletes a document revision", function( done ) {
-                        var datastore = getDatastore( datastoreDescription );
-                        expect( datastore ).not.toBe( null );
+          it('returns error fetching a wrong datatype document revision ID',
+                        function(done) {
+                          var datastore = getDatastore(datastoreDescription);
+                          expect(datastore).not.toBe(null);
 
-                        // create
-                        datastore.createDocumentFromRevision( employee, function( error, docRevision ) {
-                            expect( error ).toBe( null );
-                            expect( docRevision ).not.toBe( null );
-                            expect( docRevision._id ).toBeDefined();
-                            expect( docRevision._rev ).toBeDefined();
-                            expect( docRevision.firstName ).toBe( employee.firstName );
-
-                            // deleteDocumentFromRevision
-                            datastore.deleteDocumentFromRevision( docRevision, function( error,
-                                result ) {
-                                expect( error ).toBe( null );
-                                expect( result ).not.toBe( null );
-                                expect( result._id ).toBe(
-                                    docRevision._id );
-                                expect( result._rev ).not.toBe(
-                                    docRevision._rev );
-                                expect( result._deleted ).toBe(
-                                    true );
-                                done();
-                            } ); //end-deleteDocumentFromRevision
-                        } ); //end-create
-                    } );
-
-                    // negative tests
-                    it( "returns error if doc revision is null", function( done ) {
-                        var datastore = getDatastore( datastoreDescription );
-                        expect( datastore ).not.toBe( null );
-
-                        // datastore-updateDocumentFromRevision
-                        try {
-                            datastore.createDocumentFromRevision( null );
-                            expect( true ).toBe( false );
-                        } catch ( error ) {
-                            expect( error ).not.toBe( null );
-                            done();
-                        } //end-datastore-updateDocumentFromRevision
-                    } );
-
-                    it( "returns error if doc revision is wrong datatype", function(
-                        done ) {
-                        var datastore = getDatastore( datastoreDescription );
-                        expect( datastore ).not.toBe( null );
-
-                        // datastore-updateDocumentFromRevision
-                        try {
-                            datastore.createDocumentFromRevision( [ "foo" ] );
-                            expect( true ).toBe( false );
-                        } catch ( error ) {
-                            expect( error ).not.toBe( null );
-                            done();
-                        } //end-datastore-updateDocumentFromRevision
-                    } );
-
-                    it( "createDocumentFromRevision without body is valid", function( done ) {
-                        var datastore = getDatastore( datastoreDescription );
-                        expect( datastore ).not.toBe( null );
-
-                        // datastore-updateDocumentFromRevision
-                        datastore.createDocumentFromRevision( objWithoutBody, function( error, docRevision ) {
-                            expect( error ).toBe( null );
-                            expect( docRevision ).not.toBe(null);
-                            done();
-                        } ); //end-datastore-updateDocumentFromRevision
-                    } );
-
-                    it( "returns error if only rev field set", function( done ) {
-                        var datastore = getDatastore( datastoreDescription );
-                        expect( datastore ).not.toBe( null );
-
-                        employee._rev = "some-revision";
-
-                        // datastore-updateDocumentFromRevision
-                        try{
-                            datastore.updateDocumentFromRevision( employee, function( error, docRevision ) {
-                                expect( true ).toBe( false );
-                            });
+                          try {
+                            datastore.getDocument([ 'foo' ]);
                             expect(true).toBe(false);
-                        } catch(e){
-                            expect(e).not.toBe(null);
+                          } catch (error) {
+                            expect(error).not.toBe(null);
                             done();
-                        }
-                         //end-datastore-updateDocumentFromRevision
-                    } );
+                          }
+                        });
 
-                    it( "returns error fetching a null document revision ID", function(
-                        done ) {
-                        var datastore = getDatastore( datastoreDescription );
-                        expect( datastore ).not.toBe( null );
+          it('returns error fetching a non-exist document revision ID', function(
+              done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            datastore.getDocument( null );
-                            expect( true ).toBe( false );
-                        } catch ( error ) {
-                            expect( error ).not.toBe( null );
+            var badRevId = 'bad-revision-id';
+
+            // GetDocument
+            datastore.getDocument(badRevId, function(error, fetchedRevision) {
+              expect(error).not.toBe(null);
+              expect(fetchedRevision).not.toBeDefined();
+              done();
+            }); //End-getDocument
+          });
+
+          it('returns error deleting a null document revision', function(done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
+
+            try {
+              datastore.deleteDocumentFromRevision(null);
+              expect(true).toBe(false);
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
+
+          it('returns error deleting a wrong datatype document revision',
+                        function(done) {
+                          var datastore = getDatastore(datastoreDescription);
+                          expect(datastore).not.toBe(null);
+
+                          try {
+                            datastore.deleteDocumentFromRevision([ 'foo' ]);
+                            expect(true).toBe(false);
+                          } catch (error) {
+                            expect(error).not.toBe(null);
                             done();
-                        }
-                    } );
+                          }
+                        });
 
-                    it( "returns error fetching a wrong datatype document revision ID",
-                        function( done ) {
-                            var datastore = getDatastore( datastoreDescription );
-                            expect( datastore ).not.toBe( null );
+          it('returns error deleting a invalid document revision', function(
+              done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
 
-                            try {
-                                datastore.getDocument( [ "foo" ] );
-                                expect( true ).toBe( false );
-                            } catch ( error ) {
-                                expect( error ).not.toBe( null );
-                                done();
-                            }
-                        } );
+            employee._rev = 'bad-revision-id';
 
-                    it( "returns error fetching a non-exist document revision ID", function(
-                        done ) {
-                        var datastore = getDatastore( datastoreDescription );
-                        expect( datastore ).not.toBe( null );
+            // DeleteDocumentFromRevision
+            datastore.deleteDocumentFromRevision(employee, function(error, fetchedRevision) {
+              expect(error).not.toBe(null);
+              expect(fetchedRevision).not.toBeDefined();
+              done();
+            }); //End-deleteDocumentFromRevision
+          });
+        }); // End-Callbacks-describe-block
 
-                        var badRevId = "bad-revision-id";
+        describe('Promises', function() {
+          var employee = {
+            firstName: 'Todd',
+            lastName: 'Kaplinger',
+            numberOne: 1,
+            numberFive: 5,
+          };
+          var objWithoutBody = {
+            someParam: 'nobody',
+          };
 
-                        // getDocument
-                        datastore.getDocument( badRevId, function( error, fetchedRevision ) {
-                            expect( error ).not.toBe( null );
-                            expect( fetchedRevision ).not.toBeDefined();
-                            done();
-                        } ); //end-getDocument
-                    } );
+          it('creates a document revision', function(done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
 
-                    it( "returns error deleting a null document revision", function( done ) {
-                        var datastore = getDatastore( datastoreDescription );
-                        expect( datastore ).not.toBe( null );
-
-                        try {
-                            datastore.deleteDocumentFromRevision( null );
-                            expect( true ).toBe( false );
-                        } catch ( error ) {
-                            expect( error ).not.toBe( null );
-                            done();
-                        }
-                    } );
-
-                    it( "returns error deleting a wrong datatype document revision",
-                        function( done ) {
-                            var datastore = getDatastore( datastoreDescription );
-                            expect( datastore ).not.toBe( null );
-
-                            try {
-                                datastore.deleteDocumentFromRevision( [ "foo" ] );
-                                expect( true ).toBe( false );
-                            } catch ( error ) {
-                                expect( error ).not.toBe( null );
-                                done();
-                            }
-                        } );
-
-                    it( "returns error deleting a invalid document revision", function(
-                        done ) {
-                        var datastore = getDatastore( datastoreDescription );
-                        expect( datastore ).not.toBe( null );
-
-                        employee._rev = "bad-revision-id";
-
-                        // deleteDocumentFromRevision
-                        datastore.deleteDocumentFromRevision( employee, function( error, fetchedRevision ) {
-                            expect( error ).not.toBe( null );
-                            expect( fetchedRevision ).not.toBeDefined();
-                            done();
-                        } ); //end-deleteDocumentFromRevision
-                    } );
-                } ); // end-Callbacks-describe-block
-
-                describe( 'Promises', function() {
-                    var employee = {
-                        "firstName": "Todd",
-                        "lastName": "Kaplinger",
-                        "numberOne": 1,
-                        "numberFive": 5
-                    };
-                    var objWithoutBody = {
-                        someParam: "nobody"
-                    };
-
-                    it( "creates a document revision", function( done ) {
-                        var datastore = getDatastore( datastoreDescription );
-                        expect( datastore ).not.toBe( null );
-
-                        datastore.createDocumentFromRevision( employee )
-                            .then( function( docRevision ) {
-                                expect( docRevision ).not.toBe( null );
-                                expect( docRevision._id ).toBeDefined();
-                                expect( docRevision._rev ).toBeDefined();
-                                expect( docRevision.firstName ).toBe( employee.firstName );
-                                expect( docRevision.lastName ).toBe( employee.lastName );
-                            } )
-                            .catch( function( error ) {
-                                expect( error ).toBe( null );
-                            } )
-                            .fin( done );
-                    } );
+            datastore.createDocumentFromRevision(employee)
+                            .then(function(docRevision) {
+                              expect(docRevision).not.toBe(null);
+                              expect(docRevision._id).toBeDefined();
+                              expect(docRevision._rev).toBeDefined();
+                              expect(docRevision.firstName).toBe(employee.firstName);
+                              expect(docRevision.lastName).toBe(employee.lastName);
+                            })
+                            .catch(function(error) {
+                              expect(error).toBe(null);
+                            })
+                            .fin(done);
+          });
 
 
-                    it( "updates a document revision", function( done ) {
-                        var datastore = getDatastore( datastoreDescription );
-                        expect( datastore ).not.toBe( null );
+          it('updates a document revision', function(done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
 
-                        // update
-                        var newFirstName = "Steve";
+            // Update
+            var newFirstName = 'Steve';
 
-                        datastore.createDocumentFromRevision( employee )
-                            .then( function( docRevision ) {
-                                expect( docRevision ).not.toBe( null );
-                                expect( docRevision._id ).toBeDefined();
-                                expect( docRevision._rev ).toBeDefined();
-                                expect( docRevision.firstName ).toBe( employee.firstName );
-                                expect( docRevision.lastName ).toBe( employee.lastName );
+            datastore.createDocumentFromRevision(employee)
+                            .then(function(docRevision) {
+                              expect(docRevision).not.toBe(null);
+                              expect(docRevision._id).toBeDefined();
+                              expect(docRevision._rev).toBeDefined();
+                              expect(docRevision.firstName).toBe(employee.firstName);
+                              expect(docRevision.lastName).toBe(employee.lastName);
 
-                                docRevision.firstName = newFirstName;
+                              docRevision.firstName = newFirstName;
 
-                                return datastore.updateDocumentFromRevision( docRevision );
-                            } )
-                            .then( function( updatedRevision ) {
-                                expect( updatedRevision ).not.toBe( null );
-                                expect( updatedRevision._id ).toBeDefined();
-                                expect( updatedRevision._rev ).toBeDefined();
-                                expect( updatedRevision.firstName ).toBe(
-                                    newFirstName );
-                            } )
-                            .catch( function( error ) {
-                                expect( error ).toBe( null );
-                            } )
-                            .fin( done );
-                    } );
+                              return datastore.updateDocumentFromRevision(docRevision);
+                            })
+                            .then(function(updatedRevision) {
+                              expect(updatedRevision).not.toBe(null);
+                              expect(updatedRevision._id).toBeDefined();
+                              expect(updatedRevision._rev).toBeDefined();
+                              expect(updatedRevision.firstName).toBe(
+                                  newFirstName);
+                            })
+                            .catch(function(error) {
+                              expect(error).toBe(null);
+                            })
+                            .fin(done);
+          });
 
-                    it( "finds a document revision by docId", function( done ) {
-                        var datastore = getDatastore( datastoreDescription );
-                        expect( datastore ).not.toBe( null );
+          it('finds a document revision by docId', function(done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
 
-                        // create
-                        datastore.createDocumentFromRevision( employee )
-                            .then( function( docRevision ) {
-                                expect( docRevision ).not.toBe( null );
-                                expect( docRevision._id ).toBeDefined();
-                                expect( docRevision._rev ).toBeDefined();
-                                expect( docRevision.firstName ).toBe( employee.firstName );
+            // Create
+            datastore.createDocumentFromRevision(employee)
+                            .then(function(docRevision) {
+                              expect(docRevision).not.toBe(null);
+                              expect(docRevision._id).toBeDefined();
+                              expect(docRevision._rev).toBeDefined();
+                              expect(docRevision.firstName).toBe(employee.firstName);
 
-                                // getDocument
-                                return datastore.getDocument( docRevision._id );
-                            } )
-                            .then( function( fetchedRevision ) {
-                                expect( fetchedRevision ).not.toBe( null );
-                                expect( fetchedRevision._id ).toBeDefined();
-                                expect( fetchedRevision._rev ).toBeDefined();
-                                expect( fetchedRevision.firstName ).toBe(
-                                    employee.firstName );
-                            } )
-                            .catch( function( error ) {
-                                expect( error ).toBe( null );
-                            } )
-                            .fin( done );
-                    } );
+                              // GetDocument
+                              return datastore.getDocument(docRevision._id);
+                            })
+                            .then(function(fetchedRevision) {
+                              expect(fetchedRevision).not.toBe(null);
+                              expect(fetchedRevision._id).toBeDefined();
+                              expect(fetchedRevision._rev).toBeDefined();
+                              expect(fetchedRevision.firstName).toBe(
+                                  employee.firstName);
+                            })
+                            .catch(function(error) {
+                              expect(error).toBe(null);
+                            })
+                            .fin(done);
+          });
 
-                    it( "deletes a document revision", function( done ) {
-                        var datastore = getDatastore( datastoreDescription );
-                        expect( datastore ).not.toBe( null );
+          it('deletes a document revision', function(done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
 
-                        // create
-                        datastore.createDocumentFromRevision( employee )
-                            .then( function( docRevision ) {
-                                expect( docRevision ).not.toBe( null );
-                                expect( docRevision._id ).toBeDefined();
-                                expect( docRevision._rev ).toBeDefined();
-                                expect( docRevision.firstName ).toBe( employee.firstName );
+            // Create
+            datastore.createDocumentFromRevision(employee)
+                            .then(function(docRevision) {
+                              expect(docRevision).not.toBe(null);
+                              expect(docRevision._id).toBeDefined();
+                              expect(docRevision._rev).toBeDefined();
+                              expect(docRevision.firstName).toBe(employee.firstName);
 
-                                // deleteDocumentFromRevision
-                                return datastore.deleteDocumentFromRevision( docRevision );
-                            } )
-                            .then( function( result ) {
-                                expect( result ).not.toBe( null );
-                                expect( result._id ).toBe( docRevision._id );
-                                expect( result._rev ).not.toBe( docRevision._rev );
-                                expect( result._deleted ).toBe( true );
-                            } )
-                            .catch( function( error ) {
-                                expect( error ).not.toBe( null );
-                            } )
-                            .fin( done );
-                    } );
+                              // DeleteDocumentFromRevision
+                              return datastore.deleteDocumentFromRevision(docRevision);
+                            })
+                            .then(function(result) {
+                              expect(result).not.toBe(null);
+                              expect(result._id).toBe(docRevision._id);
+                              expect(result._rev).not.toBe(docRevision._rev);
+                              expect(result._deleted).toBe(true);
+                            })
+                            .catch(function(error) {
+                              expect(error).not.toBe(null);
+                            })
+                            .fin(done);
+          });
 
-                    // negative tests
-                    it( "returns error if doc revision is null", function( done ) {
-                        var datastore = getDatastore( datastoreDescription );
-                        expect( datastore ).not.toBe( null );
+          // Negative tests
+          it('returns error if doc revision is null', function(done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            datastore.createDocumentFromRevision( null )
-                                .then( function( docRevision ) {
-                                    expect( true ).toBe( false );
-                                } )
-                                .catch( function( error ) {
-                                    expect( true ).toBe( false );
-                                } );
-                            expect( true ).toBe( false );
-                            done();
-                        } catch ( error ) {
-                            expect( error ).not.toBe( null );
-                            done();
-                        }
-                    } );
+            try {
+              datastore.createDocumentFromRevision(null)
+                                .then(function(docRevision) {
+                                  expect(true).toBe(false);
+                                })
+                                .catch(function(error) {
+                                  expect(true).toBe(false);
+                                });
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it( "returns error if doc revision is wrong datatype", function(
-                        done ) {
-                        var datastore = getDatastore( datastoreDescription );
-                        expect( datastore ).not.toBe( null );
+          it('returns error if doc revision is wrong datatype', function(
+              done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            datastore.createDocumentFromRevision( [ 'foo' ] )
-                                .then( function( docRevision ) {
-                                    expect( true ).toBe( false );
-                                } )
-                                .catch( function( error ) {
-                                    expect( true ).toBe( false );
-                                } );
-                            expect( true ).toBe( false );
-                            done();
-                        } catch ( error ) {
-                            expect( error ).not.toBe( null );
-                            done();
-                        }
-                    } );
+            try {
+              datastore.createDocumentFromRevision([ 'foo' ])
+                                .then(function(docRevision) {
+                                  expect(true).toBe(false);
+                                })
+                                .catch(function(error) {
+                                  expect(true).toBe(false);
+                                });
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it( "createDocumentFromRevision without body is valid", function( done ) {
-                        var datastore = getDatastore( datastoreDescription );
-                        expect( datastore ).not.toBe( null );
+          it('createDocumentFromRevision without body is valid', function(done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
 
-                        // datastore-updateDocumentFromRevision
-                        datastore.createDocumentFromRevision( objWithoutBody )
-                            .then( function( docRevision ) {
-                                expect( true ).toBe( true );
-                            } )
-                            .catch( function( error ) {
-                                expect( error ).toBe( null );
-                            } )
-                            .fin( done );
-                    } );
+            // Datastore-updateDocumentFromRevision
+            datastore.createDocumentFromRevision(objWithoutBody)
+                            .then(function(docRevision) {
+                              expect(true).toBe(true);
+                            })
+                            .catch(function(error) {
+                              expect(error).toBe(null);
+                            })
+                            .fin(done);
+          });
 
-                    it( "returns updateDocumentFromRevision error if only rev field set", function( done ) {
-                        var datastore = getDatastore( datastoreDescription );
-                        expect( datastore ).not.toBe( null );
+          it('returns updateDocumentFromRevision error if only rev field set', function(done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
 
-                        employee._rev = "some-revision";
+            employee._rev = 'some-revision';
 
-                        // datastore-updateDocumentFromRevision
-                        try{
-                            datastore.updateDocumentFromRevision( employee )
-                                .catch( function( error ) {
-                                    expect( true ).toBe( false );
-                                } );
+            // Datastore-updateDocumentFromRevision
+            try {
+              datastore.updateDocumentFromRevision(employee)
+                                .catch(function(error) {
+                                  expect(true).toBe(false);
+                                });
+              expect(true).toBe(false);
+              done();
+            } catch (e) {
+              expect(e).not.toBe(null);
+              done();
+            }
+          });
+
+          it('returns error fetching if datatype incorrect', function(done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
+
+            try {
+              datastore.getDocument([ 'foo' ])
+                                .then(function(docRevision) {
+                                  expect(true).toBe(false);
+                                })
+                                .catch(function(error) {
+                                  expect(true).toBe(false);
+                                });
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
+
+          it('returns error fetching a null document revision ID', function(
+              done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
+
+            try {
+              datastore.getDocument(null)
+                                .then(function(docRevision) {
+                                  expect(true).toBe(false);
+                                })
+                                .catch(function(error) {
+                                  expect(true).toBe(false);
+                                });
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
+
+          it('returns error fetching a non-exist document revision ID', function(
+              done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
+
+            var badRevId = 'bad-revision-id';
+
+            // GetDocument
+            datastore.getDocument(badRevId)
+                            .then(function(fetchedRevision) {
+                              expect(true).toBe(false);
+                            })
+                            .catch(function(error) {
+                              expect(error).not.toBe(null);
+                            })
+                            .fin(done); //End-getDocument
+          });
+
+          it('returns error deleting a null document revision', function(done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
+
+            try {
+              datastore.deleteDocumentFromRevision(null)
+                                .then(function(result) {
+                                  expect(true).toBe(false);
+                                })
+                                .catch(function(error) {
+                                  expect(true).toBe(false);
+                                });
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
+
+          it('returns error deleting a document revision with wrong datatype',
+                        function(done) {
+                          var datastore = getDatastore(datastoreDescription);
+                          expect(datastore).not.toBe(null);
+
+                          try {
+                            datastore.deleteDocumentFromRevision([ 'foo' ])
+                                    .then(function(result) {
+                                      expect(true).toBe(false);
+                                    })
+                                    .catch(function(error) {
+                                      expect(true).toBe(false);
+                                    });
                             expect(true).toBe(false);
                             done();
-                        } catch (e) {
-                            expect(e).not.toBe(null);
+                          } catch (error) {
+                            expect(error).not.toBe(null);
                             done();
-                        }
-                    } );
+                          }
+                        });
 
-                    it( "returns error fetching if datatype incorrect", function( done ) {
-                        var datastore = getDatastore( datastoreDescription );
-                        expect( datastore ).not.toBe( null );
+          it('returns error deleting a invalid document revision', function(
+              done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            datastore.getDocument( [ "foo" ] )
-                                .then( function( docRevision ) {
-                                    expect( true ).toBe( false );
-                                } )
-                                .catch( function( error ) {
-                                    expect( true ).toBe( false );
-                                } );
-                            expect( true ).toBe( false );
-                            done();
-                        } catch ( error ) {
-                            expect( error ).not.toBe( null );
-                            done();
-                        }
-                    } );
+            employee._rev = 'bad-revision-id';
 
-                    it( "returns error fetching a null document revision ID", function(
-                        done ) {
-                        var datastore = getDatastore( datastoreDescription );
-                        expect( datastore ).not.toBe( null );
+            // DeleteDocumentFromRevision
+            datastore.deleteDocumentFromRevision(employee)
+                            .then(function(fetchedRevision) {
+                              expect(true).toBe(false);
+                            })
+                            .catch(function(error) {
+                              expect(error).not.toBe(null);
+                            })
+                            .fin(done);
+          });
+        }); // End-Promises-describe-block
+      });
+    }
 
-                        try {
-                            datastore.getDocument( null )
-                                .then( function( docRevision ) {
-                                    expect( true ).toBe( false );
-                                } )
-                                .catch( function( error ) {
-                                    expect( true ).toBe( false );
-                                } );
-                            expect( true ).toBe( false );
-                            done();
-                        } catch ( error ) {
-                            expect( error ).not.toBe( null );
-                            done();
-                        }
-                    } );
-
-                    it( "returns error fetching a non-exist document revision ID", function(
-                        done ) {
-                        var datastore = getDatastore( datastoreDescription );
-                        expect( datastore ).not.toBe( null );
-
-                        var badRevId = "bad-revision-id";
-
-                        // getDocument
-                        datastore.getDocument( badRevId )
-                            .then( function( fetchedRevision ) {
-                                expect( true ).toBe( false );
-                            } )
-                            .catch( function( error ) {
-                                expect( error ).not.toBe( null );
-                            } )
-                            .fin( done ); //end-getDocument
-                    } );
-
-                    it( "returns error deleting a null document revision", function( done ) {
-                        var datastore = getDatastore( datastoreDescription );
-                        expect( datastore ).not.toBe( null );
-
-                        try {
-                            datastore.deleteDocumentFromRevision( null )
-                                .then( function( result ) {
-                                    expect( true ).toBe( false );
-                                } )
-                                .catch( function( error ) {
-                                    expect( true ).toBe( false );
-                                } );
-                            expect( true ).toBe( false );
-                            done();
-                        } catch ( error ) {
-                            expect( error ).not.toBe( null );
-                            done();
-                        }
-                    } );
-
-                    it( "returns error deleting a document revision with wrong datatype",
-                        function( done ) {
-                            var datastore = getDatastore( datastoreDescription );
-                            expect( datastore ).not.toBe( null );
-
-                            try {
-                                datastore.deleteDocumentFromRevision( [ "foo" ] )
-                                    .then( function( result ) {
-                                        expect( true ).toBe( false );
-                                    } )
-                                    .catch( function( error ) {
-                                        expect( true ).toBe( false );
-                                    } );
-                                expect( true ).toBe( false );
-                                done();
-                            } catch ( error ) {
-                                expect( error ).not.toBe( null );
-                                done();
-                            }
-                        } );
-
-                    it( "returns error deleting a invalid document revision", function(
-                        done ) {
-                        var datastore = getDatastore( datastoreDescription );
-                        expect( datastore ).not.toBe( null );
-
-                        employee._rev = "bad-revision-id";
-
-                        // deleteDocumentFromRevision
-                        datastore.deleteDocumentFromRevision( employee )
-                            .then( function( fetchedRevision ) {
-                                expect( true ).toBe( false );
-                            } )
-                            .catch( function( error ) {
-                                expect( error ).not.toBe( null );
-                            } )
-                            .fin( done );
-                    } );
-                } ); // end-Promises-describe-block
-            } );
-        }
-
-         testCRUD( "local" );
-    } );
+    testCRUD('local');
+  });
 };

--- a/tests/DBCreateTests.js
+++ b/tests/DBCreateTests.js
@@ -13,364 +13,373 @@
  *
  */
 
-var DatastoreManager = require('cloudant-sync.DatastoreManager');
-var DBName = "testdbcreate";
+var DatastoreManager = require('cloudant-sync.DatastoreManager').DatastoreManager;
+var DBName = 'testdbcreate';
 exports.defineAutoTests = function() {
-    describe('DatastoreManager', function() {
+  describe('DatastoreManager', function() {
 
-        beforeEach(function(done) {
-            DatastoreManager.deleteDatastore(DBName)
-                .fin(done);
+    var manager;
+
+    beforeAll(function createManager(done) {
+      DatastoreManager().then(function(m) {
+        manager = m;
+        done();
+      });
+    });
+
+    beforeEach(function(done) {
+      manager.openDatastore(DBName)
+          .then(done);
+    });
+
+    afterEach(function(done) {
+      manager.deleteDatastore(DBName)
+          .fin(done);
+    });
+
+    it('should exist', function() {
+      expect(DatastoreManager).toBeDefined();
+    });
+
+    it('should contain method openDatastore', function() {
+      expect(manager.openDatastore).toBeDefined();
+    });
+
+    it('should contain method deleteDatastore', function() {
+      expect(manager.openDatastore).toBeDefined();
+    });
+
+    describe('.openDatastore(name, [callback])', function() {
+      describe('Callbacks', function() {
+        it('should create a Datastore', function(done) {
+          var storeName = DBName;
+
+          manager.openDatastore(storeName, function(error,
+              createdStore) {
+            if (error) {
+              console.log(error);
+            }
+            expect(error).toBe(null);
+            expect(createdStore).not.toBe(
+                null);
+            expect(createdStore.name).toBe(
+                storeName);
+            done();
+          });
         });
 
-        afterEach(function(done) {
-            DatastoreManager.deleteDatastore(DBName)
-                .fin(done);
+        it('should fail create a Datastore with missing name parameter', function(
+            done) {
+          try {
+            manager.openDatastore(function(error, result) {
+              expect(true).toBe(false);
+            });
+            expect(true).toBe(false);
+            done();
+          } catch (error) {
+            expect(error).not.toBe(null);
+            done();
+          }
+
         });
 
-        it('should exist', function() {
-            expect(DatastoreManager).toBeDefined();
+        it('should fail create a Datastore with null name', function(done) {
+          try {
+            manager.openDatastore(null, function(error,
+                result) {
+              expect(true).toBe(false);
+            });
+            expect(true).toBe(false);
+            done();
+          } catch (error) {
+            expect(error).not.toBe(null);
+            done();
+          }
+
         });
 
-        it("should contain method openDatastore", function() {
-            expect(DatastoreManager.openDatastore).toBeDefined();
+        it('should fail create a Datastore with empty name', function(done) {
+          try {
+            manager.openDatastore('', function(error, result) {
+              expect(true).toBe(false);
+            });
+            expect(true).toBe(false);
+            done();
+          } catch (error) {
+            expect(error).not.toBe(null);
+            done();
+          }
+
         });
 
-        it("should contain method deleteDatastore", function() {
-            expect(DatastoreManager.openDatastore).toBeDefined();
+        it('should fail create a Datastore with name of wrong type', function(
+            done) {
+          try {
+            manager.openDatastore(['foo'], function(error,
+                result) {
+              expect(true).toBe(false);
+            });
+            expect(true).toBe(false);
+            done();
+          } catch (error) {
+            expect(error).not.toBe(null);
+            done();
+          }
+
         });
+      }); // End callback tests
 
-        describe('.openDatastore(name, [callback])', function() {
-            describe('Callbacks', function() {
-                it("should create a Datastore", function(done) {
-                    var storeName = DBName;
+      describe('Promise Tests', function() {
+        it('should create a Datastore', function(done) {
+          var storeName = DBName;
 
-                    DatastoreManager.openDatastore(storeName, function(error,
-                        createdStore) {
-                        if (error) {
-                            console.log(error);
-                        }
-                        expect(error).toBe(null);
-                        expect(createdStore).not.toBe(
-                            null);
-                        expect(createdStore.name).toBe(
-                            storeName);
-                        done();
-                    });
-                });
-
-                it("should fail create a Datastore with missing name parameter", function(
-                    done) {
-                    try {
-                        DatastoreManager.openDatastore(function(error, result) {
-                            expect(true).toBe(false);
-                        });
-                        expect(true).toBe(false);
-                        done();
-                    } catch (error) {
-                        expect(error).not.toBe(null);
-                        done();
-                    }
-
-                });
-
-                it("should fail create a Datastore with null name", function(done) {
-                    try {
-                        DatastoreManager.openDatastore(null, function(error,
-                            result) {
-                            expect(true).toBe(false);
-                        });
-                        expect(true).toBe(false);
-                        done();
-                    } catch (error) {
-                        expect(error).not.toBe(null);
-                        done();
-                    }
-
-                });
-
-                it("should fail create a Datastore with empty name", function(done) {
-                    try {
-                        DatastoreManager.openDatastore("", function(error, result) {
-                            expect(true).toBe(false);
-                        });
-                        expect(true).toBe(false);
-                        done();
-                    } catch (error) {
-                        expect(error).not.toBe(null);
-                        done();
-                    }
-
-                });
-
-                it("should fail create a Datastore with name of wrong type", function(
-                    done) {
-                    try {
-                        DatastoreManager.openDatastore(['foo'], function(error,
-                            result) {
-                            expect(true).toBe(false);
-                        });
-                        expect(true).toBe(false);
-                        done();
-                    } catch (error) {
-                        expect(error).not.toBe(null);
-                        done();
-                    }
-
-                });
-            }); // end callback tests
-
-            describe('Promise Tests', function() {
-                it("should create a Datastore", function(done) {
-                    var storeName = DBName;
-
-                    DatastoreManager.openDatastore(storeName)
+          manager.openDatastore(storeName)
                         .then(function(createdStore) {
-                            expect(createdStore).not.toBe(
-                                null);
-                            expect(createdStore.name).toBe(
-                                storeName);
+                          expect(createdStore).not.toBe(
+                              null);
+                          expect(createdStore.name).toBe(
+                              storeName);
                         })
                         .fin(done);
-                });
+        });
 
-                it("should fail create a Datastore with missing name parameter", function(
-                    done) {
-                    try {
-                        DatastoreManager.openDatastore()
+        it('should fail create a Datastore with missing name parameter', function(
+            done) {
+          try {
+            manager.openDatastore()
                             .then(function(result) {
-                                expect(true).toBe(false);
+                              expect(true).toBe(false);
                             })
                             .catch(function(error) {
-                                expect(true).toBe(false);
+                              expect(true).toBe(false);
                             });
-                        expect(true).toBe(false);
-                        done();
-                    } catch (error) {
-                        expect(error).not.toBe(null);
-                        done();
-                    }
+            expect(true).toBe(false);
+            done();
+          } catch (error) {
+            expect(error).not.toBe(null);
+            done();
+          }
 
-                });
+        });
 
-                it("should fail create a Datastore with null name parameter", function(
-                    done) {
-                    try {
-                        DatastoreManager.openDatastore(null)
+        it('should fail create a Datastore with null name parameter', function(
+            done) {
+          try {
+            manager.openDatastore(null)
                             .then(function(result) {
-                                expect(true).toBe(false);
+                              expect(true).toBe(false);
                             })
                             .catch(function(error) {
-                                expect(true).toBe(false);
+                              expect(true).toBe(false);
                             });
-                        expect(true).toBe(false);
-                        done();
-                    } catch (error) {
-                        expect(error).not.toBe(null);
-                        done();
-                    }
+            expect(true).toBe(false);
+            done();
+          } catch (error) {
+            expect(error).not.toBe(null);
+            done();
+          }
 
-                });
+        });
 
-                it("should fail create a Datastore with empty name parameter", function(
-                    done) {
-                    try {
-                        DatastoreManager.openDatastore("")
+        it('should fail create a Datastore with empty name parameter', function(
+            done) {
+          try {
+            manager.openDatastore('')
                             .then(function(result) {
-                                expect(true).toBe(false);
+                              expect(true).toBe(false);
                             })
                             .catch(function(error) {
-                                expect(true).toBe(false);
+                              expect(true).toBe(false);
                             });
-                        expect(true).toBe(false);
-                        done();
-                    } catch (error) {
-                        expect(error).not.toBe(null);
-                        done();
-                    }
-                });
+            expect(true).toBe(false);
+            done();
+          } catch (error) {
+            expect(error).not.toBe(null);
+            done();
+          }
+        });
 
-                it("should fail create a Datastore with name parameter wrong type",
+        it('should fail create a Datastore with name parameter wrong type',
                     function(done) {
-                        try {
-                            DatastoreManager.openDatastore(['foo'])
+                      try {
+                        manager.openDatastore(['foo'])
                                 .then(function(result) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 })
                                 .catch(function(error) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 });
-                            expect(true).toBe(false);
-                            done();
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
+                        expect(true).toBe(false);
+                        done();
+                      } catch (error) {
+                        expect(error).not.toBe(null);
+                        done();
+                      }
                     });
-            }); // end promise tests
-        }); // end openDatastore tests
+      }); // End promise tests
+    }); // End openDatastore tests
 
-        describe('.deleteDatastore(name, [callback])', function() {
+    describe('.deleteDatastore(name, [callback])', function() {
 
-            describe('Callbacks', function() {
-                it('should delete a Datastore', function(done) {
-                    var storeName = DBName;
+      describe('Callbacks', function() {
+        it('should delete a Datastore', function(done) {
+          var storeName = DBName;
 
-                    DatastoreManager.openDatastore(storeName, function(error,
-                        createdStore) {
-                        expect(error).toBe(null);
+          manager.openDatastore(storeName, function(error,
+              createdStore) {
+            expect(error).toBe(null);
 
-                        DatastoreManager.deleteDatastore(storeName,
+            manager.deleteDatastore(storeName,
                             function(error) {
-                                expect(error).toBe(null);
-                                done();
+                              expect(error).toBe(null);
+                              done();
                             });
-                    });
-                });
+          });
+        });
 
-                it('should fail delete a Datastore with missing name parameter', function(
-                    done) {
-                    try {
-                        DatastoreManager.deleteDatastore(function(error, result) {
-                            expect(true).toBe(false);
-                        });
-                        expect(true).toBe(false);
-                        done();
-                    } catch (error) {
-                        expect(error).not.toBe(null);
-                        done();
-                    }
-                });
+        it('should fail delete a Datastore with missing name parameter', function(
+            done) {
+          try {
+            manager.deleteDatastore(function(error, result) {
+              expect(true).toBe(false);
+            });
+            expect(true).toBe(false);
+            done();
+          } catch (error) {
+            expect(error).not.toBe(null);
+            done();
+          }
+        });
 
-                it('should fail delete a Datastore with null name', function(done) {
-                    try {
-                        DatastoreManager.deleteDatastore(null, function(error,
-                            result) {
-                            expect(true).toBe(false);
-                        });
-                        expect(true).toBe(false);
-                        done();
-                    } catch (error) {
-                        expect(error).not.toBe(null);
-                        done();
-                    }
-                });
+        it('should fail delete a Datastore with null name', function(done) {
+          try {
+            manager.deleteDatastore(null, function(error,
+                result) {
+              expect(true).toBe(false);
+            });
+            expect(true).toBe(false);
+            done();
+          } catch (error) {
+            expect(error).not.toBe(null);
+            done();
+          }
+        });
 
-                it('should fail delete a Datastore with empty name', function(done) {
-                    try {
-                        DatastoreManager.deleteDatastore("", function(error,
-                            result) {
-                            expect(true).toBe(false);
-                        });
-                        expect(true).toBe(false);
-                        done();
-                    } catch (error) {
-                        expect(error).not.toBe(null);
-                        done();
-                    }
-                });
+        it('should fail delete a Datastore with empty name', function(done) {
+          try {
+            manager.deleteDatastore('', function(error,
+                result) {
+              expect(true).toBe(false);
+            });
+            expect(true).toBe(false);
+            done();
+          } catch (error) {
+            expect(error).not.toBe(null);
+            done();
+          }
+        });
 
-                it('should fail delete a Datastore with name of wrong type', function(
-                    done) {
-                    try {
-                        DatastoreManager.deleteDatastore(['foo'], function(
-                            error, result) {
-                            expect(true).toBe(false);
-                        });
-                        expect(true).toBe(false);
-                        done();
-                    } catch (error) {
-                        expect(error).not.toBe(null);
-                        done();
-                    }
-                });
-            }); // end callback tests
+        it('should fail delete a Datastore with name of wrong type', function(
+            done) {
+          try {
+            manager.deleteDatastore(['foo'], function(
+                error, result) {
+              expect(true).toBe(false);
+            });
+            expect(true).toBe(false);
+            done();
+          } catch (error) {
+            expect(error).not.toBe(null);
+            done();
+          }
+        });
+      }); // End callback tests
 
-            describe('Promises', function() {
-                it('should delete a Datastore', function(done) {
-                    var storeName = DBName;
+      describe('Promises', function() {
+        it('should delete a Datastore', function(done) {
+          var storeName = DBName;
 
-                    DatastoreManager.openDatastore(storeName)
+          manager.openDatastore(storeName)
                         .then(function(createdStore) {
-                            expect(createdStore).not.toBe(null);
-                            return DatastoreManager.deleteDatastore(storeName);
+                          expect(createdStore).not.toBe(null);
+                          return manager.deleteDatastore(storeName);
                         })
                         .catch(function(error) {
-                            expect(error).toBe(null);
+                          expect(error).toBe(null);
                         })
                         .fin(done);
-                });
+        });
 
-                it('should fail delete a Datastore with missing name parameter', function(
-                    done) {
-                    try {
-                        DatastoreManager.deleteDatastore()
+        it('should fail delete a Datastore with missing name parameter', function(
+            done) {
+          try {
+            manager.deleteDatastore()
                             .then(function(result) {
-                                expect(true).toBe(false);
+                              expect(true).toBe(false);
                             })
                             .catch(function(error) {
-                                expect(true).toBe(false);
+                              expect(true).toBe(false);
                             });
-                        expect(true).toBe(false);
-                        done();
-                    } catch (error) {
-                        expect(error).not.toBe(null);
-                        done();
-                    }
-                });
+            expect(true).toBe(false);
+            done();
+          } catch (error) {
+            expect(error).not.toBe(null);
+            done();
+          }
+        });
 
-                it('should fail delete a Datastore with null name', function(done) {
-                    try {
-                        DatastoreManager.deleteDatastore(null)
+        it('should fail delete a Datastore with null name', function(done) {
+          try {
+            manager.deleteDatastore(null)
                             .then(function(result) {
-                                expect(true).toBe(false);
+                              expect(true).toBe(false);
                             })
                             .catch(function(error) {
-                                expect(true).toBe(false);
+                              expect(true).toBe(false);
                             });
-                        expect(true).toBe(false);
-                        done();
-                    } catch (error) {
-                        expect(error).not.toBe(null);
-                        done();
-                    }
-                });
+            expect(true).toBe(false);
+            done();
+          } catch (error) {
+            expect(error).not.toBe(null);
+            done();
+          }
+        });
 
-                it('should fail delete a Datastore with empty name', function(done) {
-                    try {
-                        DatastoreManager.deleteDatastore("")
+        it('should fail delete a Datastore with empty name', function(done) {
+          try {
+            manager.deleteDatastore('')
                             .then(function(result) {
-                                expect(true).toBe(false);
+                              expect(true).toBe(false);
                             })
                             .catch(function(error) {
-                                expect(true).toBe(false);
+                              expect(true).toBe(false);
                             });
-                        expect(true).toBe(false);
-                        done();
-                    } catch (error) {
-                        expect(error).not.toBe(null);
-                        done();
-                    }
-                });
+            expect(true).toBe(false);
+            done();
+          } catch (error) {
+            expect(error).not.toBe(null);
+            done();
+          }
+        });
 
-                it('should fail delete a Datastore with name of wrong type', function(
-                    done) {
-                    try {
-                        DatastoreManager.deleteDatastore(['foo'])
+        it('should fail delete a Datastore with name of wrong type', function(
+            done) {
+          try {
+            manager.deleteDatastore(['foo'])
                             .then(function(result) {
-                                expect(true).toBe(false);
+                              expect(true).toBe(false);
                             })
                             .catch(function(error) {
-                                expect(true).toBe(false);
+                              expect(true).toBe(false);
                             });
-                        expect(true).toBe(false);
-                        done();
-                    } catch (error) {
-                        expect(error).not.toBe(null);
-                        done();
-                    }
-                });
-            }); // end promise tests
-        }); // end deleteDatastore tests
-    });
+            expect(true).toBe(false);
+            done();
+          } catch (error) {
+            expect(error).not.toBe(null);
+            done();
+          }
+        });
+      }); // End promise tests
+    }); // End deleteDatastore tests
+  });
 };

--- a/tests/IndexAndQueryTests.js
+++ b/tests/IndexAndQueryTests.js
@@ -13,977 +13,973 @@
  *
  */
 
-var DatastoreManager = require('cloudant-sync.DatastoreManager');
+var DatastoreManager = require('cloudant-sync.DatastoreManager').DatastoreManager;
 var Q = require('cloudant-sync.q');
 
-var DBName = "indexandquerydb";
-var encryptedDBName = DBName + "secure";
+var DBName = 'indexandquerydb';
+var encryptedDBName = DBName + 'secure';
 var validEncryptionOptions = {
-    password: 'passw0rd',
-    identifier: 'toolkit'
+  password: 'passw0rd',
+  identifier: 'toolkit',
 };
 
 exports.defineAutoTests = function() {
-    describe('Datastore', function() {
+  describe('Datastore', function() {
 
-        var db = null;
-        var encryptedDb = null;
+    var db = null;
+    var encryptedDb = null;
+    var manaer;
 
-        function getDatastore(datastoreDescription) {
-            switch (datastoreDescription) {
-                case "local":
-                    return db;
-                case "encrypted":
-                    return encryptedDb;
-            }
-        }
+    beforeAll(function createManager(done) {
+      DatastoreManager().then(function(m) {
+        manager = m;
+        done();
+      });
+    });
 
-        beforeEach(function(done) {
-            if (!db || !encryptedDb) {
-                DatastoreManager.deleteDatastore(DBName)
+    afterEach(function deleteDatastores(done) {
+      manager.deleteDatastore(DBName)
                     .then(function() {
-                        return DatastoreManager.deleteDatastore(encryptedDBName);
-                    })
-                    .then(function() {
-                        return DatastoreManager.openDatastore(DBName);
-                    })
+                      return manager.deleteDatastore(DBName);
+                    }).fin(done);
+    });
+
+
+    function getDatastore(datastoreDescription) {
+      return db;
+    }
+
+
+    beforeEach(function(done) {
+      manager.openDatastore(DBName)
                     .then(function(newDatastore) {
-                        db = newDatastore;
-                        return DatastoreManager.openDatastore(encryptedDBName);
-                    })
-                    .then(function(newEncryptedDatastore) {
-                        encryptedDb = newEncryptedDatastore;
+                      db = newDatastore;
                     })
                     .catch(function(error) {
-                        console.error(error);
+                      console.error(error);
                     })
                     .fin(done);
-            } else {
-                done();
-            }
+    });
+
+    function testIndex(datastoreDescription) {
+
+      // Index Tests
+      describe('Index (' + datastoreDescription + ')', function() {
+        it('.ensureIndexed exists', function() {
+          try {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(undefined);
+            expect(datastore).not.toBe(null);
+            expect(datastore.ensureIndexed).toBeDefined();
+          } catch (e) {
+            console.error('.ensureIndexed exists failed: ' + e);
+          }
         });
 
-        function testIndex(datastoreDescription) {
+        it('.deleteIndexNamed exists', function() {
+          var datastore = getDatastore(datastoreDescription);
+          expect(datastore).not.toBe(null);
+          expect(datastore.deleteIndexNamed).toBeDefined();
+        });
 
-            // Index Tests
-            describe('Index (' + datastoreDescription + ')', function() {
-                it('.ensureIndexed exists', function() {
-                    try {
-                        var datastore = getDatastore(datastoreDescription);
-                        expect(datastore).not.toBe(undefined);
-                        expect(datastore).not.toBe(null);
-                        expect(datastore.ensureIndexed).toBeDefined();
-                    } catch (e) {
-                        console.error(".ensureIndexed exists failed: " + e);
-                    }
-                });
+        describe('Callbacks', function() {
+          it('create and delete index', function(done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
+            var indexName = 'lastnameindex';
+            datastore.ensureIndexed(['lastName'], indexName, function(err, result) {
+              expect(err).toBe(null);
+              expect(result).toBe(indexName);
+              datastore.deleteIndexNamed(indexName, function(err, result) {
+                expect(err).toBe(null);
+                expect(result).toBe(true);
+                done();
+              });
+            });
+          });
 
-                it('.deleteIndexNamed exists', function() {
-                    var datastore = getDatastore(datastoreDescription);
-                    expect(datastore).not.toBe(null);
-                    expect(datastore.deleteIndexNamed).toBeDefined();
-                });
+          describe('create index negative tests', function() {
+            // Invalid index name for create
+            it('indexName is null', function(done) {
+              var datastore = getDatastore(datastoreDescription);
+              expect(datastore).not.toBe(null);
+              var indexName = null;
+              try {
+                datastore.ensureIndexed(['lastName'], indexName);
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
 
-                describe('Callbacks', function() {
-                    it('create and delete index', function(done) {
-                        var datastore = getDatastore(datastoreDescription);
-                        expect(datastore).not.toBe(null);
-                        var indexName = 'lastnameindex';
-                        datastore.ensureIndexed(['lastName'], indexName, function(err, result) {
-                            expect(err).toBe(null);
-                            expect(result).toBe(indexName);
-                            datastore.deleteIndexNamed(indexName, function(err, result) {
-                                expect(err).toBe(null);
-                                expect(result).toBe(true);
-                                done();
-                            });
-                        });
-                    });
+            it('indexName is empty string', function(done) {
+              var datastore = getDatastore(datastoreDescription);
+              expect(datastore).not.toBe(null);
+              var indexName = '';
+              try {
+                datastore.ensureIndexed(['lastName'], indexName);
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
 
-                    describe("create index negative tests", function() {
-                        // Invalid index name for create
-                        it('indexName is null', function(done) {
-                            var datastore = getDatastore(datastoreDescription);
-                            expect(datastore).not.toBe(null);
-                            var indexName = null;
-                            try {
-                                datastore.ensureIndexed(['lastName'], indexName);
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
+            it('indexName is missing', function(done) {
+              var datastore = getDatastore(datastoreDescription);
+              expect(datastore).not.toBe(null);
+              try {
+                datastore.ensureIndexed(['lastName']);
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
 
-                        it('indexName is empty string', function(done) {
-                            var datastore = getDatastore(datastoreDescription);
-                            expect(datastore).not.toBe(null);
-                            var indexName = "";
-                            try {
-                                datastore.ensureIndexed(['lastName'], indexName);
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
+            it('indexName is wrong type', function(done) {
+              var datastore = getDatastore(datastoreDescription);
+              expect(datastore).not.toBe(null);
+              try {
+                datastore.ensureIndexed(
+                    ['lastName'], ['lastName']);
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
 
-                        it('indexName is missing', function(done) {
-                            var datastore = getDatastore(datastoreDescription);
-                            expect(datastore).not.toBe(null);
-                            try {
-                                datastore.ensureIndexed(['lastName']);
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
+            // Invalid fields
+            it('fields are empty', function(done) {
+              var datastore = getDatastore(datastoreDescription);
+              var indexName = 'lastnameindex';
+              try {
+                datastore.ensureIndexed([], indexName);
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
 
-                        it('indexName is wrong type', function(done) {
-                            var datastore = getDatastore(datastoreDescription);
-                            expect(datastore).not.toBe(null);
-                            try {
-                                datastore.ensureIndexed(
-                                    ['lastName'], ['lastName']);
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
+            it('fields are null', function(done) {
+              var datastore = getDatastore(datastoreDescription);
+              var indexName = 'lastnameindex';
+              try {
+                datastore.ensureIndexed(null, indexName);
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
 
-                        // Invalid fields
-                        it('fields are empty', function(done) {
-                            var datastore = getDatastore(datastoreDescription);
-                            var indexName = 'lastnameindex';
-                            try {
-                                datastore.ensureIndexed([], indexName);
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
+            it('fields are missing', function(done) {
+              var datastore = getDatastore(datastoreDescription);
+              var indexName = 'lastnameindex';
+              try {
+                datastore.ensureIndexed(indexName);
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
 
-                        it('fields are null', function(done) {
-                            var datastore = getDatastore(datastoreDescription);
-                            var indexName = 'lastnameindex';
-                            try {
-                                datastore.ensureIndexed(null, indexName);
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
+            it('fields are wrong type', function(done) {
+              var datastore = getDatastore(datastoreDescription);
+              var indexName = 'lastnameindex';
+              try {
+                datastore.ensureIndexed({
+                  name: 'value',
+                }, indexName);
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
+          });
 
-                        it('fields are missing', function(done) {
-                            var datastore = getDatastore(datastoreDescription);
-                            var indexName = 'lastnameindex';
-                            try {
-                                datastore.ensureIndexed(indexName);
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
+          describe('delete index negative tests', function() {
+            // Invalid index name for delete
+            it('indexName is null', function(done) {
+              var datastore = getDatastore(datastoreDescription);
+              expect(datastore).not.toBe(null);
+              var indexName = null;
+              try {
+                datastore.deleteIndexNamed(indexName);
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
 
-                        it('fields are wrong type', function(done) {
-                            var datastore = getDatastore(datastoreDescription);
-                            var indexName = 'lastnameindex';
-                            try {
-                                datastore.ensureIndexed({
-                                    'name': 'value'
-                                }, indexName);
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
-                    });
+            it('indexName is empty string', function(done) {
+              var datastore = getDatastore(datastoreDescription);
+              expect(datastore).not.toBe(null);
+              var indexName = '';
+              try {
+                datastore.deleteIndexNamed(indexName);
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
 
-                    describe("delete index negative tests", function() {
-                        // Invalid index name for delete
-                        it('indexName is null', function(done) {
-                            var datastore = getDatastore(datastoreDescription);
-                            expect(datastore).not.toBe(null);
-                            var indexName = null;
-                            try {
-                                datastore.deleteIndexNamed(indexName);
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
+            it('indexName is missing', function(done) {
+              var datastore = getDatastore(datastoreDescription);
+              expect(datastore).not.toBe(null);
+              try {
+                datastore.deleteIndexNamed();
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
 
-                        it('indexName is empty string', function(done) {
-                            var datastore = getDatastore(datastoreDescription);
-                            expect(datastore).not.toBe(null);
-                            var indexName = "";
-                            try {
-                                datastore.deleteIndexNamed(indexName);
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
+            it('indexName is wrong type', function(done) {
+              var datastore = getDatastore(datastoreDescription);
+              expect(datastore).not.toBe(null);
+              try {
+                datastore.deleteIndexNamed(
+                    ['lastName']);
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
+          });
 
-                        it('indexName is missing', function(done) {
-                            var datastore = getDatastore(datastoreDescription);
-                            expect(datastore).not.toBe(null);
-                            try {
-                                datastore.deleteIndexNamed();
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
+        }); // End Callback Tests
 
-                        it('indexName is wrong type', function(done) {
-                            var datastore = getDatastore(datastoreDescription);
-                            expect(datastore).not.toBe(null);
-                            try {
-                                datastore.deleteIndexNamed(
-                                    ['lastName']);
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
-                    });
-
-                }); // End Callback Tests
-
-                describe('Promises', function() {
-                    it('create and delete index', function(done) {
-                        var datastore = getDatastore(datastoreDescription);
-                        expect(datastore).not.toBe(null);
-                        var indexName = 'lastnameindex';
-                        datastore.ensureIndexed(['lastName'], indexName)
+        describe('Promises', function() {
+          it('create and delete index', function(done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
+            var indexName = 'lastnameindex';
+            datastore.ensureIndexed(['lastName'], indexName)
                             .then(function(result) {
-                                expect(result).toBe(indexName);
-                                return datastore.deleteIndexNamed(indexName);
+                              expect(result).toBe(indexName);
+                              return datastore.deleteIndexNamed(indexName);
                             })
                             .then(function(result) {
-                                expect(result).toBe(true);
+                              expect(result).toBe(true);
                             })
                             .catch(function(err) {
-                                expect(err).toBe(null);
+                              expect(err).toBe(null);
                             })
                             .fin(done);
-                    });
+          });
 
-                    describe("create index negative tests", function() {
-                        // invalid index name for create
-                        it("indexName is null", function(done) {
-                            var datastore = getDatastore(datastoreDescription);
-                            expect(datastore).not.toBe(null);
-                            try {
-                                var indexName = null;
-                                datastore.ensureIndexed(['lastName'], indexName)
+          describe('create index negative tests', function() {
+            // Invalid index name for create
+            it('indexName is null', function(done) {
+              var datastore = getDatastore(datastoreDescription);
+              expect(datastore).not.toBe(null);
+              try {
+                var indexName = null;
+                datastore.ensureIndexed(['lastName'], indexName)
                                     .then(function() {
-                                        expect(true).toBe(false);
+                                      expect(true).toBe(false);
                                     })
                                     .catch(function(error) {
-                                        expect(true).toBe(false);
+                                      expect(true).toBe(false);
                                     });
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
-
-                        it("indexName is empty string", function(done) {
-                            var datastore = getDatastore(datastoreDescription);
-                            expect(datastore).not.toBe(null);
-                            try {
-                                var indexName = "";
-                                datastore.ensureIndexed(['lastName'], indexName)
-                                    .then(function() {
-                                        expect(true).toBe(false);
-                                    })
-                                    .catch(function(error) {
-                                        expect(true).toBe(false);
-                                    });
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
-
-                        it("indexName is missing", function(done) {
-                            var datastore = getDatastore(datastoreDescription);
-                            expect(datastore).not.toBe(null);
-                            try {
-                                datastore.ensureIndexed(['lastName'])
-                                    .then(function() {
-                                        expect(true).toBe(false);
-                                    })
-                                    .catch(function(error) {
-                                        expect(true).toBe(false);
-                                    });
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
-
-                        it("indexName is wrong type", function(done) {
-                            var datastore = getDatastore(datastoreDescription);
-                            expect(datastore).not.toBe(null);
-                            try {
-                                datastore.ensureIndexed(['lastName'], ['lastName'])
-                                    .then(function() {
-                                        expect(true).toBe(false);
-                                    })
-                                    .catch(function(error) {
-                                        expect(true).toBe(false);
-                                    });
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
-
-                        // invalid field tests
-                        it("fields are null", function(done) {
-                            var datastore = getDatastore(datastoreDescription);
-                            expect(datastore).not.toBe(null);
-                            try {
-                                var indexName = 'lastnameindex';
-                                datastore.ensureIndexed(null, indexName)
-                                    .then(function() {
-                                        expect(true).toBe(false);
-                                    })
-                                    .catch(function(error) {
-                                        expect(true).toBe(false);
-                                    });
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
-
-                        it("fields are empty", function(done) {
-                            var datastore = getDatastore(datastoreDescription);
-                            expect(datastore).not.toBe(null);
-                            try {
-                                var indexName = 'lastnameindex';
-                                datastore.ensureIndexed([], indexName)
-                                    .then(function() {
-                                        expect(true).toBe(false);
-                                    })
-                                    .catch(function(error) {
-                                        expect(true).toBe(false);
-                                    });
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
-
-                        it("fields are missing", function(done) {
-                            var datastore = getDatastore(datastoreDescription);
-                            expect(datastore).not.toBe(null);
-                            try {
-                                var indexName = 'lastnameindex';
-                                datastore.ensureIndexed(indexName)
-                                    .then(function() {
-                                        expect(true).toBe(false);
-                                    })
-                                    .catch(function(error) {
-                                        expect(true).toBe(false);
-                                    });
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
-
-                        it("fields are wrong type", function(done) {
-                            var datastore = getDatastore(datastoreDescription);
-                            expect(datastore).not.toBe(null);
-                            try {
-                                var indexName = 'lastnameindex';
-                                datastore.ensureIndexed({
-                                        'name': 'value'
-                                    }, indexName)
-                                    .then(function() {
-                                        expect(true).toBe(false);
-                                    })
-                                    .catch(function(error) {
-                                        expect(true).toBe(false);
-                                    });
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
-                    }); // end create negative tests
-
-                    describe("delete index negative tests", function() {
-                        // invalid index name for delete
-                        it("indexName is null", function(done) {
-                            var datastore = getDatastore(datastoreDescription);
-                            expect(datastore).not.toBe(null);
-                            try {
-                                var indexName = null;
-                                datastore.deleteIndexNamed(indexName)
-                                    .then(function() {
-                                        expect(true).toBe(false);
-                                    })
-                                    .catch(function(error) {
-                                        expect(true).toBe(false);
-                                    });
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
-
-                        it("indexName is empty string", function(done) {
-                            var datastore = getDatastore(datastoreDescription);
-                            expect(datastore).not.toBe(null);
-                            try {
-                                var indexName = "";
-                                datastore.deleteIndexNamed(indexName)
-                                    .then(function() {
-                                        expect(true).toBe(false);
-                                    })
-                                    .catch(function(error) {
-                                        expect(true).toBe(false);
-                                    });
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
-
-                        it("indexName is missing", function(done) {
-                            var datastore = getDatastore(datastoreDescription);
-                            expect(datastore).not.toBe(null);
-                            try {
-                                datastore.deleteIndexNamed()
-                                    .then(function() {
-                                        expect(true).toBe(false);
-                                    })
-                                    .catch(function(error) {
-                                        expect(true).toBe(false);
-                                    });
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
-
-                        it("indexName is wrong type", function(done) {
-                            var datastore = getDatastore(datastoreDescription);
-                            expect(datastore).not.toBe(null);
-                            try {
-                                datastore.deleteIndexNamed(['lastName'])
-                                    .then(function() {
-                                        expect(true).toBe(false);
-                                    })
-                                    .catch(function(error) {
-                                        expect(true).toBe(false);
-                                    });
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
-                    }); // end delete index tests
-
-                }); // End Promise Tests
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
             });
-        }
 
-        function testQuery(datastoreDescription) {
-            var indexName = 'ageIndex';
-            var ageKey = 'age';
-            var nameKey = 'name';
-            var nameValue = 'data';
-            var indexedFields = [ageKey];
-
-            // Index Tests
-            describe('Query (' + datastoreDescription + ')', function() {
-                var employee = null;
-
-                beforeEach(function() {
-
-                });
-
-                beforeEach(function(done) {
-                    jasmine.addMatchers({
-                        toBeLessThanOrEqualTo: function(util, customEqualityTesters) {
-                            return {
-                                compare: function(actual, expected) {
-                                    var result = {};
-                                    result.pass = actual <= expected;
-
-                                    if (!result.pass) {
-                                        result.message = "Expected " + actual + " to be less than or equal to " + expected;
-                                    }
-                                    return result;
-                                }
-                            };
-                        }
-                    });
-
-                    try {
-                        var datastore = getDatastore(datastoreDescription);
-                        expect(datastore).not.toBe(null);
-                        setupQueryTests(0, 5, datastore)
-                            .then(function() {
-                                return setupQueryTests(5, 10, datastore);
-                            })
-                            .then(function() {
-                                return setupQueryTests(10, 15, datastore);
-                            })
-                            .then(function() {
-                                return setupQueryTests(15, 20, datastore);
-                            })
-                            .catch(function(error) {
-                                expect(error).toBe(null);
-                            })
-                            .fin(done);
-                    } catch (e) {
-                        console.error("Query beforeEach failed: " + e);
-                    }
-                });
-
-                it('.find exists', function() {
-                    var datastore = getDatastore(datastoreDescription);
-                    expect(datastore).not.toBe(null);
-                    expect(datastore.find).toBeDefined();
-                });
-
-                describe('Callbacks', function() {
-
-                    it('query for doc', function(done) {
-                        var query = {
-                            selector: {
-                                age: 0
-                            }
-                        };
-
-                        var datastore = getDatastore(datastoreDescription);
-                        expect(datastore).not.toBe(null);
-
-                        datastore.find(query,
-                            function(err, results) {
-                                expect(err).toBe(null);
-                                expect(results).not.toBe(null);
-
-                                results.forEach(function(result) {
-                                    expect(result[ageKey]).toBe(0);
-                                    expect(result[nameKey]).toBe(nameValue + 0);
-                                });
-
-                                done();
-                            });
-                    });
-
-                    it('should perform a query for equality', function(done) {
-                        var query = {
-                            selector: {
-                                age: {
-                                    $eq: 5
-                                }
-                            }
-                        };
-
-                        var datastore = getDatastore(datastoreDescription);
-                        expect(datastore).not.toBe(null);
-
-                        datastore.find(query,
-                            function(err, results) {
-                                expect(err).toBe(null);
-                                expect(results).not.toBe(null);
-
-                                results.forEach(function(result) {
-                                    expect(result[ageKey]).toBe(5);
-                                    expect(result[nameKey]).toBe(nameValue + 5);
-                                });
-
-                                done();
-                            });
-                    });
-
-                    it('should perform a query for inequality', function(done) {
-                        var query = {
-                            selector: {
-                                age: {
-                                    $gt: 1
-                                }
-                            }
-                        };
-
-                        var datastore = getDatastore(datastoreDescription);
-                        expect(datastore).not.toBe(null);
-
-                        datastore.find(query,
-                            function(err, results) {
-                                expect(err).toBe(null);
-                                expect(results).not.toBe(null);
-
-                                results.forEach(function(result) {
-                                    expect(result[ageKey]).toBeGreaterThan(1);
-                                });
-                                done();
-                            });
-                    });
-
-                    it('should perform a query with sort options', function(done) {
-                        var query = {
-                            selector: {
-                                age: {
-                                    $gte: 0
-                                }
-                            },
-                            sort: [{
-                                age: 'desc'
-                            }]
-                        };
-
-                        var datastore = getDatastore(datastoreDescription);
-                        expect(datastore).not.toBe(null);
-
-                        datastore.find(query,
-                            function(err, results) {
-                                expect(err).toBe(null);
-                                expect(results).not.toBe(null);
-
-                                var age = results[0][ageKey];
-                                results.forEach(function(result) {
-                                    expect(result[ageKey]).toBeLessThanOrEqualTo(age);
-                                    age = result[ageKey];
-                                });
-
-                                done();
-                            });
-                    });
-
-                    it('should perform a query with skip and limit options', function(done) {
-                        var query = {
-                            selector: {
-                                age: {
-                                    $gte: 0
-                                }
-                            },
-                            sort: [{
-                                age: 'asc'
-                            }],
-                            limit: 3,
-                            skip: 3
-                        };
-
-                        var datastore = getDatastore(datastoreDescription);
-                        expect(datastore).not.toBe(null);
-
-                        datastore.find(query,
-                            function(err, results) {
-                                expect(err).toBe(null);
-                                expect(results).not.toBe(null);
-                                expect(results.length).toBe(3);
-
-                                done();
-                            });
-                    });
-
-                    describe("Query negative tests", function() {
-
-                        it('should throw for null query options', function(done) {
-                            var datastore = getDatastore(datastoreDescription);
-                            expect(datastore).not.toBe(null);
-
-                            try {
-                                datastore.find(null);
-                                expect(true).toBe(false);
-                                done();
-                            } catch (e) {
-                                expect(e).not.toBe(null);
-                                done();
-                            }
-
-                        });
-
-                        it('should reject bad query params', function(done) {
-                            var query = {
-                                42: {}
-                            };
-
-                            var datastore = getDatastore(datastoreDescription);
-                            expect(datastore).not.toBe(null);
-                            try {
-                                datastore.find(query);
-                                expect(true).toBe(false);
-                                done();
-                            } catch (e) {
-                                expect(e).not.toBe(null);
-                                done();
-                            }
-                        });
-                    }); // end query negative tests
-                }); // End Callback Tests
-
-                describe('Promises', function() {
-                    it('query for doc', function(done) {
-                        var datastore = getDatastore(datastoreDescription);
-                        expect(datastore).not.toBe(null);
-
-                        var query = {
-                            selector: {
-                                age: 0
-                            }
-                        };
-
-                        datastore.find(query)
-                            .then(function(results) {
-                                expect(results).not.toBe(null);
-
-                                results.forEach(function(result) {
-                                    expect(result[ageKey]).toBe(0);
-                                    expect(result[nameKey]).toBe(nameValue + 0);
-                                });
-                            })
-                            .catch(function(error) {
-                                expect(true).toBe(false);
-                            })
-                            .fin(done);
-                    });
-
-                    it('should perform a query for equality', function(done) {
-                        var datastore = getDatastore(datastoreDescription);
-                        expect(datastore).not.toBe(null);
-
-                        var query = {
-                            selector: {
-                                age: {
-                                    $eq: 5
-                                }
-                            }
-                        };
-
-                        datastore.find(query)
-                            .then(function(results) {
-                                expect(results).not.toBe(null);
-
-                                results.forEach(function(result) {
-                                    expect(result[ageKey]).toBe(5);
-                                    expect(result[nameKey]).toBe(nameValue + 5);
-                                });
-                            })
-                            .catch(function(error) {
-                                expect(true).toBe(false);
-                            })
-                            .fin(done);
-                    });
-
-                    it('should perform a query for inequality', function(done) {
-                        var datastore = getDatastore(datastoreDescription);
-                        expect(datastore).not.toBe(null);
-
-                        var query = {
-                            selector: {
-                                age: {
-                                    $gt: 1
-                                }
-                            }
-                        };
-
-                        datastore.find(query)
-                            .then(function(results) {
-                                expect(results).not.toBe(null);
-
-                                results.forEach(function(result) {
-                                    expect(result[ageKey]).toBeGreaterThan(1);
-                                });
-                                done();
-                            })
-                            .catch(function(error) {
-                                expect(true).toBe(false);
-                            })
-                            .fin(done);
-                    });
-
-                    it('should perform a query with sort options', function(done) {
-                        var datastore = getDatastore(datastoreDescription);
-                        expect(datastore).not.toBe(null);
-
-                        var query = {
-                            selector: {
-                                age: {
-                                    $gte: 0
-                                }
-                            },
-                            sort: [{
-                                age: 'desc'
-                            }]
-                        };
-
-                        datastore.find(query)
-                            .then(function(results) {
-                                expect(results).not.toBe(null);
-
-                                var age = results[0][ageKey];
-                                results.forEach(function(result) {
-                                    expect(result[ageKey]).toBeLessThanOrEqualTo(age);
-                                    age = result[ageKey];
-                                });
-
-                                done();
-                            })
-                            .catch(function(error) {
-                                expect(true).toBe(false);
-                            })
-                            .fin(done);
-                    });
-
-                    it('should perform a query with skip and limit options', function(done) {
-                        var datastore = getDatastore(datastoreDescription);
-                        expect(datastore).not.toBe(null);
-
-                        var query = {
-                            selector: {
-                                age: {
-                                    $gte: 0
-                                }
-                            },
-                            sort: [{
-                                age: 'asc'
-                            }],
-                            limit: 3,
-                            skip: 3
-                        };
-
-                        datastore.find(query)
-                            .then(function(results) {
-                                expect(results).not.toBe(null);
-                                expect(results.length).toBe(3);
-                                done();
-                            })
-                            .catch(function(error) {
-                                expect(true).toBe(false);
-                            })
-                            .fin(done);
-                    });
-
-                    describe("Query negative tests", function() {
-
-                        it('should throw for null query options', function(done) {
-                            var datastore = getDatastore(datastoreDescription);
-                            expect(datastore).not.toBe(null);
-
-                            try {
-                                datastore.find(null)
+            it('indexName is empty string', function(done) {
+              var datastore = getDatastore(datastoreDescription);
+              expect(datastore).not.toBe(null);
+              try {
+                var indexName = '';
+                datastore.ensureIndexed(['lastName'], indexName)
                                     .then(function() {
-                                        expect(true).toBe(false);
+                                      expect(true).toBe(false);
                                     })
                                     .catch(function(error) {
-                                        expect(true).toBe(false);
+                                      expect(true).toBe(false);
                                     });
-                                expect(true).toBe(false);
-                                done();
-                            } catch (error) {
-                                expect(error).not.toBe(null);
-                                done();
-                            }
-                        });
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
 
-                        it('should reject bad query params', function(done) {
-                            var query = {
-                                42: {}
-                            };
+            it('indexName is missing', function(done) {
+              var datastore = getDatastore(datastoreDescription);
+              expect(datastore).not.toBe(null);
+              try {
+                datastore.ensureIndexed(['lastName'])
+                                    .then(function() {
+                                      expect(true).toBe(false);
+                                    })
+                                    .catch(function(error) {
+                                      expect(true).toBe(false);
+                                    });
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
 
-                            var datastore = getDatastore(datastoreDescription);
-                            expect(datastore).not.toBe(null);
-                            try {
-                                datastore.find(query)
+            it('indexName is wrong type', function(done) {
+              var datastore = getDatastore(datastoreDescription);
+              expect(datastore).not.toBe(null);
+              try {
+                datastore.ensureIndexed(['lastName'], ['lastName'])
+                                    .then(function() {
+                                      expect(true).toBe(false);
+                                    })
+                                    .catch(function(error) {
+                                      expect(true).toBe(false);
+                                    });
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
+
+            // Invalid field tests
+            it('fields are null', function(done) {
+              var datastore = getDatastore(datastoreDescription);
+              expect(datastore).not.toBe(null);
+              try {
+                var indexName = 'lastnameindex';
+                datastore.ensureIndexed(null, indexName)
+                                    .then(function() {
+                                      expect(true).toBe(false);
+                                    })
+                                    .catch(function(error) {
+                                      expect(true).toBe(false);
+                                    });
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
+
+            it('fields are empty', function(done) {
+              var datastore = getDatastore(datastoreDescription);
+              expect(datastore).not.toBe(null);
+              try {
+                var indexName = 'lastnameindex';
+                datastore.ensureIndexed([], indexName)
+                                    .then(function() {
+                                      expect(true).toBe(false);
+                                    })
+                                    .catch(function(error) {
+                                      expect(true).toBe(false);
+                                    });
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
+
+            it('fields are missing', function(done) {
+              var datastore = getDatastore(datastoreDescription);
+              expect(datastore).not.toBe(null);
+              try {
+                var indexName = 'lastnameindex';
+                datastore.ensureIndexed(indexName)
+                                    .then(function() {
+                                      expect(true).toBe(false);
+                                    })
+                                    .catch(function(error) {
+                                      expect(true).toBe(false);
+                                    });
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
+
+            it('fields are wrong type', function(done) {
+              var datastore = getDatastore(datastoreDescription);
+              expect(datastore).not.toBe(null);
+              try {
+                var indexName = 'lastnameindex';
+                datastore.ensureIndexed({
+                  name: 'value',
+                }, indexName)
+                                    .then(function() {
+                                      expect(true).toBe(false);
+                                    })
+                                    .catch(function(error) {
+                                      expect(true).toBe(false);
+                                    });
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
+          }); // End create negative tests
+
+          describe('delete index negative tests', function() {
+            // Invalid index name for delete
+            it('indexName is null', function(done) {
+              var datastore = getDatastore(datastoreDescription);
+              expect(datastore).not.toBe(null);
+              try {
+                var indexName = null;
+                datastore.deleteIndexNamed(indexName)
+                                    .then(function() {
+                                      expect(true).toBe(false);
+                                    })
+                                    .catch(function(error) {
+                                      expect(true).toBe(false);
+                                    });
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
+
+            it('indexName is empty string', function(done) {
+              var datastore = getDatastore(datastoreDescription);
+              expect(datastore).not.toBe(null);
+              try {
+                var indexName = '';
+                datastore.deleteIndexNamed(indexName)
+                                    .then(function() {
+                                      expect(true).toBe(false);
+                                    })
+                                    .catch(function(error) {
+                                      expect(true).toBe(false);
+                                    });
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
+
+            it('indexName is missing', function(done) {
+              var datastore = getDatastore(datastoreDescription);
+              expect(datastore).not.toBe(null);
+              try {
+                datastore.deleteIndexNamed()
+                                    .then(function() {
+                                      expect(true).toBe(false);
+                                    })
+                                    .catch(function(error) {
+                                      expect(true).toBe(false);
+                                    });
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
+
+            it('indexName is wrong type', function(done) {
+              var datastore = getDatastore(datastoreDescription);
+              expect(datastore).not.toBe(null);
+              try {
+                datastore.deleteIndexNamed(['lastName'])
+                                    .then(function() {
+                                      expect(true).toBe(false);
+                                    })
+                                    .catch(function(error) {
+                                      expect(true).toBe(false);
+                                    });
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
+          }); // End delete index tests
+
+        }); // End Promise Tests
+      });
+    }
+
+    function testQuery(datastoreDescription) {
+      var indexName = 'ageIndex';
+      var ageKey = 'age';
+      var nameKey = 'name';
+      var nameValue = 'data';
+      var indexedFields = [ageKey];
+
+      // Index Tests
+      describe('Query (' + datastoreDescription + ')', function() {
+        var employee = null;
+
+        beforeEach(function() {
+
+        });
+
+        beforeEach(function(done) {
+          jasmine.addMatchers({
+            toBeLessThanOrEqualTo: function(util, customEqualityTesters) {
+              return {
+                compare: function(actual, expected) {
+                  var result = {};
+                  result.pass = actual <= expected;
+
+                  if (!result.pass) {
+                    result.message = 'Expected ' + actual + ' to be less than or equal to ' + expected;
+                  }
+                  return result;
+                },
+              };
+            },
+          });
+
+          try {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
+            setupQueryTests(0, 5, datastore)
+                            .then(function() {
+                              return setupQueryTests(5, 10, datastore);
+                            })
+                            .then(function() {
+                              return setupQueryTests(10, 15, datastore);
+                            })
+                            .then(function() {
+                              return setupQueryTests(15, 20, datastore);
+                            })
+                            .catch(function(error) {
+                              expect(error).toBe(null);
+                            })
+                            .fin(done);
+          } catch (e) {
+            console.error('Query beforeEach failed: ' + e);
+          }
+        });
+
+        it('.find exists', function() {
+          var datastore = getDatastore(datastoreDescription);
+          expect(datastore).not.toBe(null);
+          expect(datastore.find).toBeDefined();
+        });
+
+        describe('Callbacks', function() {
+
+          it('query for doc', function(done) {
+            var query = {
+              selector: {
+                age: 0,
+              },
+            };
+
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
+
+            datastore.find(query,
+                            function(err, results) {
+                              expect(err).toBe(null);
+                              expect(results).not.toBe(null);
+
+                              results.forEach(function(result) {
+                                expect(result[ageKey]).toBe(0);
+                                expect(result[nameKey]).toBe(nameValue + 0);
+                              });
+
+                              done();
+                            });
+          });
+
+          it('should perform a query for equality', function(done) {
+            var query = {
+              selector: {
+                age: {
+                  $eq: 5,
+                },
+              },
+            };
+
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
+
+            datastore.find(query,
+                            function(err, results) {
+                              expect(err).toBe(null);
+                              expect(results).not.toBe(null);
+
+                              results.forEach(function(result) {
+                                expect(result[ageKey]).toBe(5);
+                                expect(result[nameKey]).toBe(nameValue + 5);
+                              });
+
+                              done();
+                            });
+          });
+
+          it('should perform a query for inequality', function(done) {
+            var query = {
+              selector: {
+                age: {
+                  $gt: 1,
+                },
+              },
+            };
+
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
+
+            datastore.find(query,
+                            function(err, results) {
+                              expect(err).toBe(null);
+                              expect(results).not.toBe(null);
+
+                              results.forEach(function(result) {
+                                expect(result[ageKey]).toBeGreaterThan(1);
+                              });
+                              done();
+                            });
+          });
+
+          it('should perform a query with sort options', function(done) {
+            var query = {
+              selector: {
+                age: {
+                  $gte: 0,
+                },
+              },
+              sort: [{
+                age: 'desc',
+              },],
+            };
+
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
+
+            datastore.find(query,
+                            function(err, results) {
+                              expect(err).toBe(null);
+                              expect(results).not.toBe(null);
+
+                              var age = results[0][ageKey];
+                              results.forEach(function(result) {
+                                expect(result[ageKey]).toBeLessThanOrEqualTo(age);
+                                age = result[ageKey];
+                              });
+
+                              done();
+                            });
+          });
+
+          it('should perform a query with skip and limit options', function(done) {
+            var query = {
+              selector: {
+                age: {
+                  $gte: 0,
+                },
+              },
+              sort: [{
+                age: 'asc',
+              },],
+              limit: 3,
+              skip: 3,
+            };
+
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
+
+            datastore.find(query,
+                            function(err, results) {
+                              expect(err).toBe(null);
+                              expect(results).not.toBe(null);
+                              expect(results.length).toBe(3);
+
+                              done();
+                            });
+          });
+
+          describe('Query negative tests', function() {
+
+            it('should throw for null query options', function(done) {
+              var datastore = getDatastore(datastoreDescription);
+              expect(datastore).not.toBe(null);
+
+              try {
+                datastore.find(null);
+                expect(true).toBe(false);
+                done();
+              } catch (e) {
+                expect(e).not.toBe(null);
+                done();
+              }
+
+            });
+
+            it('should reject bad query params', function(done) {
+              var query = {
+                42: {},
+              };
+
+              var datastore = getDatastore(datastoreDescription);
+              expect(datastore).not.toBe(null);
+              try {
+                datastore.find(query);
+                expect(true).toBe(false);
+                done();
+              } catch (e) {
+                expect(e).not.toBe(null);
+                done();
+              }
+            });
+          }); // End query negative tests
+        }); // End Callback Tests
+
+        describe('Promises', function() {
+          it('query for doc', function(done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
+
+            var query = {
+              selector: {
+                age: 0,
+              },
+            };
+
+            datastore.find(query)
+                            .then(function(results) {
+                              expect(results).not.toBe(null);
+
+                              results.forEach(function(result) {
+                                expect(result[ageKey]).toBe(0);
+                                expect(result[nameKey]).toBe(nameValue + 0);
+                              });
+                            })
+                            .catch(function(error) {
+                              expect(true).toBe(false);
+                            })
+                            .fin(done);
+          });
+
+          it('should perform a query for equality', function(done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
+
+            var query = {
+              selector: {
+                age: {
+                  $eq: 5,
+                },
+              },
+            };
+
+            datastore.find(query)
+                            .then(function(results) {
+                              expect(results).not.toBe(null);
+
+                              results.forEach(function(result) {
+                                expect(result[ageKey]).toBe(5);
+                                expect(result[nameKey]).toBe(nameValue + 5);
+                              });
+                            })
+                            .catch(function(error) {
+                              expect(true).toBe(false);
+                            })
+                            .fin(done);
+          });
+
+          it('should perform a query for inequality', function(done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
+
+            var query = {
+              selector: {
+                age: {
+                  $gt: 1,
+                },
+              },
+            };
+
+            datastore.find(query)
+                            .then(function(results) {
+                              expect(results).not.toBe(null);
+
+                              results.forEach(function(result) {
+                                expect(result[ageKey]).toBeGreaterThan(1);
+                              });
+                              done();
+                            })
+                            .catch(function(error) {
+                              expect(true).toBe(false);
+                            })
+                            .fin(done);
+          });
+
+          it('should perform a query with sort options', function(done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
+
+            var query = {
+              selector: {
+                age: {
+                  $gte: 0,
+                },
+              },
+              sort: [{
+                age: 'desc',
+              },],
+            };
+
+            datastore.find(query)
+                            .then(function(results) {
+                              expect(results).not.toBe(null);
+
+                              var age = results[0][ageKey];
+                              results.forEach(function(result) {
+                                expect(result[ageKey]).toBeLessThanOrEqualTo(age);
+                                age = result[ageKey];
+                              });
+
+                              done();
+                            })
+                            .catch(function(error) {
+                              expect(true).toBe(false);
+                            })
+                            .fin(done);
+          });
+
+          it('should perform a query with skip and limit options', function(done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
+
+            var query = {
+              selector: {
+                age: {
+                  $gte: 0,
+                },
+              },
+              sort: [{
+                age: 'asc',
+              },],
+              limit: 3,
+              skip: 3,
+            };
+
+            datastore.find(query)
+                            .then(function(results) {
+                              expect(results).not.toBe(null);
+                              expect(results.length).toBe(3);
+                              done();
+                            })
+                            .catch(function(error) {
+                              expect(true).toBe(false);
+                            })
+                            .fin(done);
+          });
+
+          describe('Query negative tests', function() {
+
+            it('should throw for null query options', function(done) {
+              var datastore = getDatastore(datastoreDescription);
+              expect(datastore).not.toBe(null);
+
+              try {
+                datastore.find(null)
+                                    .then(function() {
+                                      expect(true).toBe(false);
+                                    })
+                                    .catch(function(error) {
+                                      expect(true).toBe(false);
+                                    });
+                expect(true).toBe(false);
+                done();
+              } catch (error) {
+                expect(error).not.toBe(null);
+                done();
+              }
+            });
+
+            it('should reject bad query params', function(done) {
+              var query = {
+                42: {},
+              };
+
+              var datastore = getDatastore(datastoreDescription);
+              expect(datastore).not.toBe(null);
+              try {
+                datastore.find(query)
                                     .then(function(results) {
-                                        expect(true).toBe(false);
+                                      expect(true).toBe(false);
                                     })
                                     .catch(function(error) {
-                                        expect(true).toBe(false);
+                                      expect(true).toBe(false);
                                     });
-                                expect(true).toBe(false);
-                                done();
-                            } catch (e) {
-                                expect(e).not.toBe(null);
-                                done();
-                            }
-                        });
-                    }); // end query negative tests
-                }); // End Promise Tests
+                expect(true).toBe(false);
+                done();
+              } catch (e) {
+                expect(e).not.toBe(null);
+                done();
+              }
             });
+          }); // End query negative tests
+        }); // End Promise Tests
+      });
 
-            function setupQueryTests(start, end, datastore) {
-                try {
+      function setupQueryTests(start, end, datastore) {
+        try {
 
-                    var promises = [];
-                    promises.push(datastore.ensureIndexed(indexedFields, indexName));
-                    for (var i = start; i < end; i++) {
-                        var person = {};
-                        person[ageKey] = i;
-                        person[nameKey] = nameValue + i;
+          var promises = [];
+          promises.push(datastore.ensureIndexed(indexedFields, indexName));
+          for (var i = start; i < end; i++) {
+            var person = {};
+            person[ageKey] = i;
+            person[nameKey] = nameValue + i;
 
-                        promises.push(datastore.createDocumentFromRevision(person));
-                    }
+            promises.push(datastore.createDocumentFromRevision(person));
+          }
 
-                    return Q.all(promises);
-                } catch (e) {
-                    console.error("Query failed setup: " + e);
-                }
-            }
+          return Q.all(promises);
+        } catch (e) {
+          console.error('Query failed setup: ' + e);
         }
+      }
+    }
 
-        testIndex("local");
-        testIndex("encrypted");
+    testIndex('local');
 
-        testQuery("local");
-        testQuery("encrypted");
-    });
+    testQuery('local');
+  });
 };

--- a/tests/ReplicationTests.js
+++ b/tests/ReplicationTests.js
@@ -13,2231 +13,2246 @@
  *
  */
 
-var DBName = "replicationdb";
+var DBName = 'replicationdb';
+
 try {
-    var DatastoreManager = require('cloudant-sync.DatastoreManager');
-    var ReplicatorBuilder = require('cloudant-sync.ReplicatorBuilder');
+  var DatastoreManager = require('cloudant-sync.DatastoreManager').DatastoreManager;
+  var ReplicatorBuilder = require('cloudant-sync.ReplicatorBuilder');
 } catch (e) {
-    console.log("error: " + e);
+  console.log('error: ' + e);
 }
 var TestUtil = require('cloudant-sync-tests.TestUtil');
 var Q = require('cloudant-sync.q');
 
 exports.defineAutoTests = function() {
 
-    describe('Replication', function() {
+  describe('Replication', function() {
+
+    var validEncryptionOptions = {
+      password: 'passw0rd',
+      identifier: 'toolkit',
+    };
+
+    var manager;
+
+    var badtoken = 'badtoken';
+    var badtype = 'badtype';
+    var baddatastore = 'baddatastore';
+    var baduri = 'baduri';
+
+    var uri = TestUtil.LOCAL_COUCH_URL + '/animaldb';
+    var localStore = null;
+    var encryptedStore = null;
+    var storeName = null;
+    var encryptedStoreName = null;
+
+    var defaultTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+
+    beforeAll(function createManager(done) {
+      DatastoreManager().then(function(m) {
+        manager = m;
+      })
+      .fin(done);
+    });
+
+    afterEach(function deleteDatastores(done) {
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = defaultTimeout;
+      manager.deleteDatastore(DBName)
+            .then(function() {
+              return manager.deleteDatastore(DBName);
+            }).fin(done);
+    });
 
 
-        var badtoken = 'badtoken';
-        var badtype = 'badtype';
-        var baddatastore = 'baddatastore';
-        var baduri = 'baduri';
+    function getDatastore(storeDescription) {
+      return localStore;
+    }
 
-        var uri = TestUtil.LOCAL_COUCH_URL + '/animaldb';
-        var localStore = null;
-        var storeName = null;
-
-        var defaultTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
-
-        function getDatastore(storeDescription) {
-            return localStore;
-        }
-        beforeEach(function(done) {
-          if (!localStore){
-            DatastoreManager.deleteDatastore(DBName)
-                .then(function() {
-                    return DatastoreManager.openDatastore(DBName);
-                })
+    beforeEach(function(done) {
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = defaultTimeout;
+      manager.openDatastore(DBName)
                 .then(function(newLocalStore) {
-                    localStore = newLocalStore;
+                  localStore = newLocalStore;
                 })
                 .catch(function(error) {
-                    console.error(error);
+                  console.error(error);
                 })
                 .fin(done);
-          } else {
-            done();
-          }
+    });
+
+    function testReplication(storeDescription) {
+
+      describe('ReplicatorBuilder (' + storeDescription + ')', function() {
+        it('should return a new ReplicatorBuilder', function() {
+          var builder = new ReplicatorBuilder();
+          expect(builder).not.toBe(null);
         });
 
-        afterEach(function () {
-          jasmine.DEFAULT_TIMEOUT_INTERVAL = defaultTimeout;
+        it('should contain method push', function() {
+          var builder = new ReplicatorBuilder();
+          expect(builder.push).toBeDefined();
         });
 
-        function testReplication(storeDescription) {
+        it('should contain method pull', function() {
+          var builder = new ReplicatorBuilder();
+          expect(builder.pull).toBeDefined();
+        });
 
-            describe('ReplicatorBuilder (' + storeDescription + ')', function() {
-                it('should return a new ReplicatorBuilder', function() {
-                    var builder = new ReplicatorBuilder();
-                    expect(builder).not.toBe(null);
-                });
+        it('should contain method to', function() {
+          var builder = new ReplicatorBuilder();
+          expect(builder.to).toBeDefined();
+        });
 
-                it("should contain method push", function() {
-                    var builder = new ReplicatorBuilder();
-                    expect(builder.push).toBeDefined();
-                });
+        it('should contain method from', function() {
+          var builder = new ReplicatorBuilder();
+          expect(builder.from).toBeDefined();
+        });
 
-                it("should contain method pull", function() {
-                    var builder = new ReplicatorBuilder();
-                    expect(builder.pull).toBeDefined();
-                });
+        it('should contain method build', function() {
+          var builder = new ReplicatorBuilder();
+          expect(builder.build).toBeDefined();
+        });
 
-                it("should contain method to", function() {
-                    var builder = new ReplicatorBuilder();
-                    expect(builder.to).toBeDefined();
-                });
+        describe('Callbacks', function() {
+          it('should create a pull replicator', function(done) {
+            try {
+              var datastore = getDatastore(storeDescription);
+              expect(datastore).not.toBe(null);
+              var builder = new ReplicatorBuilder();
+              expect(builder).not.toBe(null);
 
-                it("should contain method from", function() {
-                    var builder = new ReplicatorBuilder();
-                    expect(builder.from).toBeDefined();
-                });
+              builder.pull().from(uri).to(datastore).build(function(error, replicator) {
+                expect(error).toBe(null);
+                expect(replicator.token).not.toBe(null);
+                replicator.token = badtoken; // Assert readonly
+                expect(replicator.token).not.toBe(badtoken);
 
-                it("should contain method build", function() {
-                    var builder = new ReplicatorBuilder();
-                    expect(builder.build).toBeDefined();
-                });
+                expect(replicator.type).toBe('pull');
+                replicator.type = badtype; // Assert readonly
+                expect(replicator.type).not.toBe(badtype);
 
-                describe('Callbacks', function() {
-                    it("should create a pull replicator", function(done) {
-                        try {
-                            var datastore = getDatastore(storeDescription);
-                            expect(datastore).not.toBe(null);
-                            var builder = new ReplicatorBuilder();
-                            expect(builder).not.toBe(null);
+                expect(replicator.datastore).toBe(datastore);
+                replicator.datastore = baddatastore; // Assert readonly
+                expect(replicator.datastore).not.toBe(baddatastore);
 
-                            builder.pull().from(uri).to(datastore).build(function(error, replicator) {
-                                expect(error).toBe(null);
-                                expect(replicator.token).not.toBe(null);
-                                replicator.token = badtoken; // assert readonly
-                                expect(replicator.token).not.toBe(badtoken);
+                expect(replicator.uri).toBe(uri);
+                replicator.uri = baduri; // Assert readonly
+                expect(replicator.uri).not.toBe(baduri);
+                done();
+              });
+            } catch (e) {
+              expect(e).toBe(null);
+              done();
+            }
+          });
 
-                                expect(replicator.type).toBe('pull');
-                                replicator.type = badtype; // assert readonly
-                                expect(replicator.type).not.toBe(badtype);
+          it('should create a pull replicator with a request and response interceptor', function(done) {
+            try {
+              var datastore = getDatastore(storeDescription);
+              expect(datastore).not.toBe(null);
+              var builder = new ReplicatorBuilder();
+              expect(builder).not.toBe(null);
 
-                                expect(replicator.datastore).toBe(datastore);
-                                replicator.datastore = baddatastore; // assert readonly
-                                expect(replicator.datastore).not.toBe(baddatastore);
+              var interceptor = function(context) {
+                context.done();
+              };
 
-                                expect(replicator.uri).toBe(uri);
-                                replicator.uri = baduri; // assert readonly
-                                expect(replicator.uri).not.toBe(baduri);
-                                done();
-                            });
-                        } catch (e) {
-                            expect(e).toBe(null);
-                            done();
-                        }
-                    });
-
-                    it("should create a pull replicator with a request and response interceptor", function(done) {
-                        try {
-                            var datastore = getDatastore(storeDescription);
-                            expect(datastore).not.toBe(null);
-                            var builder = new ReplicatorBuilder();
-                            expect(builder).not.toBe(null);
-
-                            var interceptor = function (context) {
-                                context.done();
-                            };
-
-                            builder.pull().from(uri).to(datastore)
-                                .addRequestInterceptors(interceptor)
-                                .addResponseInterceptors(interceptor)
+              builder.pull().from(uri).to(datastore)
+                  .addRequestInterceptors(interceptor)
+                  .addResponseInterceptors(interceptor)
                                 .build(function(error, replicator) {
-                                expect(error).toBe(null);
-                                expect(replicator.token).not.toBe(null);
-                                replicator.token = badtoken; // assert readonly
-                                expect(replicator.token).not.toBe(badtoken);
+                                  expect(error).toBe(null);
+                                  expect(replicator.token).not.toBe(null);
+                                  replicator.token = badtoken; // Assert readonly
+                                  expect(replicator.token).not.toBe(badtoken);
 
-                                expect(replicator.type).toBe('pull');
-                                replicator.type = badtype; // assert readonly
-                                expect(replicator.type).not.toBe(badtype);
+                                  expect(replicator.type).toBe('pull');
+                                  replicator.type = badtype; // Assert readonly
+                                  expect(replicator.type).not.toBe(badtype);
 
-                                expect(replicator.datastore).toBe(datastore);
-                                replicator.datastore = baddatastore; // assert readonly
-                                expect(replicator.datastore).not.toBe(baddatastore);
+                                  expect(replicator.datastore).toBe(datastore);
+                                  replicator.datastore = baddatastore; // Assert readonly
+                                  expect(replicator.datastore).not.toBe(baddatastore);
 
-                                expect(replicator.uri).toBe(uri);
-                                replicator.uri = baduri; // assert readonly
-                                expect(replicator.uri).not.toBe(baduri);
-                                done();
-                            });
-                        } catch (e) {
-                            expect(e).toBe(null);
-                            done();
-                        }
-                    });
+                                  expect(replicator.uri).toBe(uri);
+                                  replicator.uri = baduri; // Assert readonly
+                                  expect(replicator.uri).not.toBe(baduri);
+                                  done();
+                                });
+            } catch (e) {
+              expect(e).toBe(null);
+              done();
+            }
+          });
 
-                    it("should create a pull replicator with a comma separated list of request and response interceptors", function(done) {
-                        try {
-                            var datastore = getDatastore(storeDescription);
-                            expect(datastore).not.toBe(null);
-                            var builder = new ReplicatorBuilder();
-                            expect(builder).not.toBe(null);
+          it('should create a pull replicator with a comma separated list of request and response interceptors', function(done) {
+            try {
+              var datastore = getDatastore(storeDescription);
+              expect(datastore).not.toBe(null);
+              var builder = new ReplicatorBuilder();
+              expect(builder).not.toBe(null);
 
-                            var interceptor1 = function (context) {
-                                context.done();
-                            };
+              var interceptor1 = function(context) {
+                context.done();
+              };
 
-                            var interceptor2 = function (context) {
-                                context.done();
-                            };
+              var interceptor2 = function(context) {
+                context.done();
+              };
 
-                            builder.pull().from(uri).to(datastore)
-                                .addRequestInterceptors(interceptor1, interceptor2)
-                                .addResponseInterceptors(interceptor1, interceptor2)
+              builder.pull().from(uri).to(datastore)
+                  .addRequestInterceptors(interceptor1, interceptor2)
+                  .addResponseInterceptors(interceptor1, interceptor2)
                                 .build(function(error, replicator) {
-                                expect(error).toBe(null);
-                                expect(replicator.token).not.toBe(null);
-                                replicator.token = badtoken; // assert readonly
-                                expect(replicator.token).not.toBe(badtoken);
+                                  expect(error).toBe(null);
+                                  expect(replicator.token).not.toBe(null);
+                                  replicator.token = badtoken; // Assert readonly
+                                  expect(replicator.token).not.toBe(badtoken);
 
-                                expect(replicator.type).toBe('pull');
-                                replicator.type = badtype; // assert readonly
-                                expect(replicator.type).not.toBe(badtype);
+                                  expect(replicator.type).toBe('pull');
+                                  replicator.type = badtype; // Assert readonly
+                                  expect(replicator.type).not.toBe(badtype);
 
-                                expect(replicator.datastore).toBe(datastore);
-                                replicator.datastore = baddatastore; // assert readonly
-                                expect(replicator.datastore).not.toBe(baddatastore);
+                                  expect(replicator.datastore).toBe(datastore);
+                                  replicator.datastore = baddatastore; // Assert readonly
+                                  expect(replicator.datastore).not.toBe(baddatastore);
 
-                                expect(replicator.uri).toBe(uri);
-                                replicator.uri = baduri; // assert readonly
-                                expect(replicator.uri).not.toBe(baduri);
-                                done();
-                            });
-                        } catch (e) {
-                            expect(e).toBe(null);
-                            done();
-                        }
-                    });
+                                  expect(replicator.uri).toBe(uri);
+                                  replicator.uri = baduri; // Assert readonly
+                                  expect(replicator.uri).not.toBe(baduri);
+                                  done();
+                                });
+            } catch (e) {
+              expect(e).toBe(null);
+              done();
+            }
+          });
 
-                    it("should create a pull replicator with an array of request and response interceptors", function(done) {
-                        try {
-                            var datastore = getDatastore(storeDescription);
-                            expect(datastore).not.toBe(null);
-                            var builder = new ReplicatorBuilder();
-                            expect(builder).not.toBe(null);
+          it('should create a pull replicator with an array of request and response interceptors', function(done) {
+            try {
+              var datastore = getDatastore(storeDescription);
+              expect(datastore).not.toBe(null);
+              var builder = new ReplicatorBuilder();
+              expect(builder).not.toBe(null);
 
-                            var interceptor1 = function (context) {
-                                context.done();
-                            };
+              var interceptor1 = function(context) {
+                context.done();
+              };
 
-                            var interceptor2 = function (context) {
-                                context.done();
-                            };
+              var interceptor2 = function(context) {
+                context.done();
+              };
 
-                            var interceptors = [interceptor1, interceptor2];
+              var interceptors = [interceptor1, interceptor2];
 
-                            builder.pull().from(uri).to(datastore)
-                                .addRequestInterceptors(interceptors)
-                                .addResponseInterceptors(interceptors)
+              builder.pull().from(uri).to(datastore)
+                  .addRequestInterceptors(interceptors)
+                  .addResponseInterceptors(interceptors)
                                 .build(function(error, replicator) {
-                                expect(error).toBe(null);
-                                expect(replicator.token).not.toBe(null);
-                                replicator.token = badtoken; // assert readonly
-                                expect(replicator.token).not.toBe(badtoken);
+                                  expect(error).toBe(null);
+                                  expect(replicator.token).not.toBe(null);
+                                  replicator.token = badtoken; // Assert readonly
+                                  expect(replicator.token).not.toBe(badtoken);
 
-                                expect(replicator.type).toBe('pull');
-                                replicator.type = badtype; // assert readonly
-                                expect(replicator.type).not.toBe(badtype);
+                                  expect(replicator.type).toBe('pull');
+                                  replicator.type = badtype; // Assert readonly
+                                  expect(replicator.type).not.toBe(badtype);
 
-                                expect(replicator.datastore).toBe(datastore);
-                                replicator.datastore = baddatastore; // assert readonly
-                                expect(replicator.datastore).not.toBe(baddatastore);
+                                  expect(replicator.datastore).toBe(datastore);
+                                  replicator.datastore = baddatastore; // Assert readonly
+                                  expect(replicator.datastore).not.toBe(baddatastore);
 
-                                expect(replicator.uri).toBe(uri);
-                                replicator.uri = baduri; // assert readonly
-                                expect(replicator.uri).not.toBe(baduri);
-                                done();
-                            });
-                        } catch (e) {
-                            expect(e).toBe(null);
-                            done();
-                        }
-                    });
+                                  expect(replicator.uri).toBe(uri);
+                                  replicator.uri = baduri; // Assert readonly
+                                  expect(replicator.uri).not.toBe(baduri);
+                                  done();
+                                });
+            } catch (e) {
+              expect(e).toBe(null);
+              done();
+            }
+          });
 
-                    it("should create a push replicator", function(done) {
-                        try {
-                            var datastore = getDatastore(storeDescription);
-                            expect(datastore).not.toBe(null);
-                            var builder = new ReplicatorBuilder();
-                            expect(builder).not.toBe(null);
+          it('should create a push replicator', function(done) {
+            try {
+              var datastore = getDatastore(storeDescription);
+              expect(datastore).not.toBe(null);
+              var builder = new ReplicatorBuilder();
+              expect(builder).not.toBe(null);
 
-                            builder.push().from(datastore).to(uri).build(function(error, replicator) {
-                                expect(error).toBe(null);
-                                expect(replicator.token).not.toBe(null);
-                                replicator.token = badtoken; // assert readonly
-                                expect(replicator.token).not.toBe(badtoken);
+              builder.push().from(datastore).to(uri).build(function(error, replicator) {
+                expect(error).toBe(null);
+                expect(replicator.token).not.toBe(null);
+                replicator.token = badtoken; // Assert readonly
+                expect(replicator.token).not.toBe(badtoken);
 
-                                expect(replicator.type).toBe('push');
-                                replicator.type = badtype; // assert readonly
-                                expect(replicator.type).not.toBe(badtype);
+                expect(replicator.type).toBe('push');
+                replicator.type = badtype; // Assert readonly
+                expect(replicator.type).not.toBe(badtype);
 
-                                expect(replicator.datastore).toBe(datastore);
-                                replicator.datastore = baddatastore; // assert readonly
-                                expect(replicator.datastore).not.toBe(baddatastore);
+                expect(replicator.datastore).toBe(datastore);
+                replicator.datastore = baddatastore; // Assert readonly
+                expect(replicator.datastore).not.toBe(baddatastore);
 
-                                expect(replicator.uri).toBe(uri);
-                                replicator.uri = baduri; // assert readonly
-                                expect(replicator.uri).not.toBe(baduri);
-                                done();
-                            });
-                        } catch (e) {
-                            expect(e).toBe(null);
-                            done();
-                        }
-                    });
+                expect(replicator.uri).toBe(uri);
+                replicator.uri = baduri; // Assert readonly
+                expect(replicator.uri).not.toBe(baduri);
+                done();
+              });
+            } catch (e) {
+              expect(e).toBe(null);
+              done();
+            }
+          });
 
-                    it("should create a push replicator with a request and response interceptor", function(done) {
-                        try {
-                            var datastore = getDatastore(storeDescription);
-                            expect(datastore).not.toBe(null);
-                            var builder = new ReplicatorBuilder();
-                            expect(builder).not.toBe(null);
+          it('should create a push replicator with a request and response interceptor', function(done) {
+            try {
+              var datastore = getDatastore(storeDescription);
+              expect(datastore).not.toBe(null);
+              var builder = new ReplicatorBuilder();
+              expect(builder).not.toBe(null);
 
-                            var interceptor = function (context) {
-                                context.done();
-                            };
+              var interceptor = function(context) {
+                context.done();
+              };
 
-                            builder.push().from(datastore).to(uri)
-                                .addRequestInterceptors(interceptor)
-                                .addResponseInterceptors(interceptor)
+              builder.push().from(datastore).to(uri)
+                  .addRequestInterceptors(interceptor)
+                  .addResponseInterceptors(interceptor)
                                 .build(function(error, replicator) {
-                                expect(error).toBe(null);
-                                expect(replicator.token).not.toBe(null);
-                                replicator.token = badtoken; // assert readonly
-                                expect(replicator.token).not.toBe(badtoken);
+                                  expect(error).toBe(null);
+                                  expect(replicator.token).not.toBe(null);
+                                  replicator.token = badtoken; // Assert readonly
+                                  expect(replicator.token).not.toBe(badtoken);
 
-                                expect(replicator.type).toBe('push');
-                                replicator.type = badtype; // assert readonly
-                                expect(replicator.type).not.toBe(badtype);
+                                  expect(replicator.type).toBe('push');
+                                  replicator.type = badtype; // Assert readonly
+                                  expect(replicator.type).not.toBe(badtype);
 
-                                expect(replicator.datastore).toBe(datastore);
-                                replicator.datastore = baddatastore; // assert readonly
-                                expect(replicator.datastore).not.toBe(baddatastore);
+                                  expect(replicator.datastore).toBe(datastore);
+                                  replicator.datastore = baddatastore; // Assert readonly
+                                  expect(replicator.datastore).not.toBe(baddatastore);
 
-                                expect(replicator.uri).toBe(uri);
-                                replicator.uri = baduri; // assert readonly
-                                expect(replicator.uri).not.toBe(baduri);
-                                done();
-                            });
-                        } catch (e) {
-                            expect(e).toBe(null);
-                            done();
-                        }
-                    });
+                                  expect(replicator.uri).toBe(uri);
+                                  replicator.uri = baduri; // Assert readonly
+                                  expect(replicator.uri).not.toBe(baduri);
+                                  done();
+                                });
+            } catch (e) {
+              expect(e).toBe(null);
+              done();
+            }
+          });
 
-                    it("should create a push replicator with a comma separated list of request and response interceptors", function(done) {
-                        try {
-                            var datastore = getDatastore(storeDescription);
-                            expect(datastore).not.toBe(null);
-                            var builder = new ReplicatorBuilder();
-                            expect(builder).not.toBe(null);
+          it('should create a push replicator with a comma separated list of request and response interceptors', function(done) {
+            try {
+              var datastore = getDatastore(storeDescription);
+              expect(datastore).not.toBe(null);
+              var builder = new ReplicatorBuilder();
+              expect(builder).not.toBe(null);
 
-                            var interceptor1 = function (context) {
-                                context.done();
-                            };
+              var interceptor1 = function(context) {
+                context.done();
+              };
 
-                            var interceptor2 = function (context) {
-                                context.done();
-                            };
+              var interceptor2 = function(context) {
+                context.done();
+              };
 
-                            builder.push().from(datastore).to(uri)
-                                .addRequestInterceptors(interceptor1, interceptor2)
-                                .addResponseInterceptors(interceptor1, interceptor2)
+              builder.push().from(datastore).to(uri)
+                  .addRequestInterceptors(interceptor1, interceptor2)
+                  .addResponseInterceptors(interceptor1, interceptor2)
                                 .build(function(error, replicator) {
-                                expect(error).toBe(null);
-                                expect(replicator.token).not.toBe(null);
-                                replicator.token = badtoken; // assert readonly
-                                expect(replicator.token).not.toBe(badtoken);
+                                  expect(error).toBe(null);
+                                  expect(replicator.token).not.toBe(null);
+                                  replicator.token = badtoken; // Assert readonly
+                                  expect(replicator.token).not.toBe(badtoken);
 
-                                expect(replicator.type).toBe('push');
-                                replicator.type = badtype; // assert readonly
-                                expect(replicator.type).not.toBe(badtype);
+                                  expect(replicator.type).toBe('push');
+                                  replicator.type = badtype; // Assert readonly
+                                  expect(replicator.type).not.toBe(badtype);
 
-                                expect(replicator.datastore).toBe(datastore);
-                                replicator.datastore = baddatastore; // assert readonly
-                                expect(replicator.datastore).not.toBe(baddatastore);
+                                  expect(replicator.datastore).toBe(datastore);
+                                  replicator.datastore = baddatastore; // Assert readonly
+                                  expect(replicator.datastore).not.toBe(baddatastore);
 
-                                expect(replicator.uri).toBe(uri);
-                                replicator.uri = baduri; // assert readonly
-                                expect(replicator.uri).not.toBe(baduri);
-                                done();
-                            });
-                        } catch (e) {
-                            expect(e).toBe(null);
-                            done();
-                        }
-                    });
+                                  expect(replicator.uri).toBe(uri);
+                                  replicator.uri = baduri; // Assert readonly
+                                  expect(replicator.uri).not.toBe(baduri);
+                                  done();
+                                });
+            } catch (e) {
+              expect(e).toBe(null);
+              done();
+            }
+          });
 
-                    it("should create a push replicator with an array of request and response interceptors", function(done) {
-                        try {
-                            var datastore = getDatastore(storeDescription);
-                            expect(datastore).not.toBe(null);
-                            var builder = new ReplicatorBuilder();
-                            expect(builder).not.toBe(null);
+          it('should create a push replicator with an array of request and response interceptors', function(done) {
+            try {
+              var datastore = getDatastore(storeDescription);
+              expect(datastore).not.toBe(null);
+              var builder = new ReplicatorBuilder();
+              expect(builder).not.toBe(null);
 
-                            var interceptor1 = function (context) {
-                                context.done();
-                            };
+              var interceptor1 = function(context) {
+                context.done();
+              };
 
-                            var interceptor2 = function (context) {
-                                context.done();
-                            };
+              var interceptor2 = function(context) {
+                context.done();
+              };
 
-                            var interceptors = [interceptor1, interceptor2];
+              var interceptors = [interceptor1, interceptor2];
 
-                            builder.push().from(datastore).to(uri)
-                                .addRequestInterceptors(interceptors)
-                                .addResponseInterceptors(interceptors)
+              builder.push().from(datastore).to(uri)
+                  .addRequestInterceptors(interceptors)
+                  .addResponseInterceptors(interceptors)
                                 .build(function(error, replicator) {
-                                expect(error).toBe(null);
-                                expect(replicator.token).not.toBe(null);
-                                replicator.token = badtoken; // assert readonly
-                                expect(replicator.token).not.toBe(badtoken);
+                                  expect(error).toBe(null);
+                                  expect(replicator.token).not.toBe(null);
+                                  replicator.token = badtoken; // Assert readonly
+                                  expect(replicator.token).not.toBe(badtoken);
 
-                                expect(replicator.type).toBe('push');
-                                replicator.type = badtype; // assert readonly
-                                expect(replicator.type).not.toBe(badtype);
+                                  expect(replicator.type).toBe('push');
+                                  replicator.type = badtype; // Assert readonly
+                                  expect(replicator.type).not.toBe(badtype);
 
-                                expect(replicator.datastore).toBe(datastore);
-                                replicator.datastore = baddatastore; // assert readonly
-                                expect(replicator.datastore).not.toBe(baddatastore);
+                                  expect(replicator.datastore).toBe(datastore);
+                                  replicator.datastore = baddatastore; // Assert readonly
+                                  expect(replicator.datastore).not.toBe(baddatastore);
 
-                                expect(replicator.uri).toBe(uri);
-                                replicator.uri = baduri; // assert readonly
-                                expect(replicator.uri).not.toBe(baduri);
-                                done();
-                            });
-                        } catch (e) {
-                            expect(e).toBe(null);
-                            done();
-                        }
-                    });
+                                  expect(replicator.uri).toBe(uri);
+                                  replicator.uri = baduri; // Assert readonly
+                                  expect(replicator.uri).not.toBe(baduri);
+                                  done();
+                                });
+            } catch (e) {
+              expect(e).toBe(null);
+              done();
+            }
+          });
 
-                    it('should create two replicators with different tokens', function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('should create two replicators with different tokens', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        var firstReplicator;
-                        var calls = 0;
+            var firstReplicator;
+            var calls = 0;
 
-                        function callback(error, replicator) {
-                            expect(error).toBe(null);
-                            calls++;
-                            if (calls === 2) {
-                                expect(firstReplicator.token).not.toEqual(replicator.token);
-                                done();
-                            } else {
-                                firstReplicator = replicator;
-                            }
-                        }
+            function callback(error, replicator) {
+              expect(error).toBe(null);
+              calls++;
+              if (calls === 2) {
+                expect(firstReplicator.token).not.toEqual(replicator.token);
+                done();
+              } else {
+                firstReplicator = replicator;
+              }
+            }
 
-                        new ReplicatorBuilder().pull().to(datastore).from(uri).build(callback);
-                        new ReplicatorBuilder().push().from(datastore).to(uri).build(callback);
-                    });
+            new ReplicatorBuilder().pull().to(datastore).from(uri).build(callback);
+            new ReplicatorBuilder().push().from(datastore).to(uri).build(callback);
+          });
 
-                    // negative tests
-                    it("throws error if push source is null", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          // Negative tests
+          it('throws error if push source is null', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().push().from(null).to(uri).build(function(error,
-                                replicator) {
-                                expect(true).toBe(false);
-                            });
-                            expect(true).toBe(false);
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
-                    it("throws error if push target is null", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+            try {
+              new ReplicatorBuilder().push().from(null).to(uri).build(function(error,
+                  replicator) {
+                expect(true).toBe(false);
+              });
+              expect(true).toBe(false);
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
+          it('throws error if push target is null', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().push().from(datastore).to(null).build(function(
-                                error, replicator) {
-                                expect(true).toBe(false);
-                            });
-                            expect(true).toBe(false);
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
-                    it("throws error if pull source is null", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+            try {
+              new ReplicatorBuilder().push().from(datastore).to(null).build(function(
+                  error, replicator) {
+                expect(true).toBe(false);
+              });
+              expect(true).toBe(false);
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
+          it('throws error if pull source is null', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(null).to(datastore).build(function(
-                                error, replicator) {
-                                expect(true).toBe(false);
-                            });
-                            expect(true).toBe(false);
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
-                    it("throws error if pull target is null", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+            try {
+              new ReplicatorBuilder().pull().from(null).to(datastore).build(function(
+                  error, replicator) {
+                expect(true).toBe(false);
+              });
+              expect(true).toBe(false);
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
+          it('throws error if pull target is null', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(uri).to(null).build(function(error,
-                                replicator) {
-                                expect(true).toBe(false);
-                            });
-                            expect(true).toBe(false);
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+            try {
+              new ReplicatorBuilder().pull().from(uri).to(null).build(function(error,
+                  replicator) {
+                expect(true).toBe(false);
+              });
+              expect(true).toBe(false);
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it("throws error if pull source is not a String", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('throws error if pull source is not a String', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from([]).to(datastore).build(function(error,
-                                replicator) {
-                                expect(true).toBe(false);
-                            });
-                            expect(true).toBe(false);
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
-                    it("throws error if pull target is not a Datastore", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+            try {
+              new ReplicatorBuilder().pull().from([]).to(datastore).build(function(error,
+                  replicator) {
+                expect(true).toBe(false);
+              });
+              expect(true).toBe(false);
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
+          it('throws error if pull target is not a Datastore', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(uri).to([]).build(function(error,
-                                replicator) {
-                                expect(true).toBe(false);
-                            });
-                            expect(true).toBe(false);
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+            try {
+              new ReplicatorBuilder().pull().from(uri).to([]).build(function(error,
+                  replicator) {
+                expect(true).toBe(false);
+              });
+              expect(true).toBe(false);
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it("throws error if push source is not a Datastore", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('throws error if push source is not a Datastore', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().push().from([]).to(uri).build(function(error,
-                                replicator) {
-                                expect(true).toBe(false);
-                            });
-                            expect(true).toBe(false);
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
-                    it("throws error if push target is not a String", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+            try {
+              new ReplicatorBuilder().push().from([]).to(uri).build(function(error,
+                  replicator) {
+                expect(true).toBe(false);
+              });
+              expect(true).toBe(false);
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
+          it('throws error if push target is not a String', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().push().from(datastore).to([]).build(function(error,
-                                replicator) {
-                                expect(true).toBe(false);
-                            });
-                            expect(true).toBe(false);
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+            try {
+              new ReplicatorBuilder().push().from(datastore).to([]).build(function(error,
+                  replicator) {
+                expect(true).toBe(false);
+              });
+              expect(true).toBe(false);
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it("throws error if push target is not set", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('throws error if push target is not set', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().push().from(datastore).build(function(error,
-                                replicator) {
-                                expect(true).toBe(false);
-                            });
-                            expect(true).toBe(false);
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
-                    it("throws error if pull target is not set", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+            try {
+              new ReplicatorBuilder().push().from(datastore).build(function(error,
+                  replicator) {
+                expect(true).toBe(false);
+              });
+              expect(true).toBe(false);
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
+          it('throws error if pull target is not set', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(uri).build(function(error, replicator) {
-                                expect(true).toBe(false);
-                            });
-                            expect(true).toBe(false);
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
-                    it("throws error if push source is not set", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+            try {
+              new ReplicatorBuilder().pull().from(uri).build(function(error, replicator) {
+                expect(true).toBe(false);
+              });
+              expect(true).toBe(false);
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
+          it('throws error if push source is not set', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().push().to(uri).build(function(error, replicator) {
-                                expect(true).toBe(false);
-                            });
-                            expect(true).toBe(false);
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
-                    it("throws error if pull target is not set", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+            try {
+              new ReplicatorBuilder().push().to(uri).build(function(error, replicator) {
+                expect(true).toBe(false);
+              });
+              expect(true).toBe(false);
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
+          it('throws error if pull target is not set', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().to(datastore).build(function(error,
-                                replicator) {
-                                expect(true).toBe(false);
-                            });
-                            expect(true).toBe(false);
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
-                    it("throws error if replication type is not set", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+            try {
+              new ReplicatorBuilder().pull().to(datastore).build(function(error,
+                  replicator) {
+                expect(true).toBe(false);
+              });
+              expect(true).toBe(false);
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
+          it('throws error if replication type is not set', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().from(datastore).to(uri).build(function(error,
-                                replicator) {
-                                expect(true).toBe(false);
-                            });
-                            expect(true).toBe(false);
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+            try {
+              new ReplicatorBuilder().from(datastore).to(uri).build(function(error,
+                  replicator) {
+                expect(true).toBe(false);
+              });
+              expect(true).toBe(false);
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it("throws error if request interceptor is null", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('throws error if request interceptor is null', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(datastore).to(uri).addRequestInterceptors(null).build(function(error,
-                                replicator) {
-                                expect(true).toBe(false);
-                            });
-                            expect(true).toBe(false);
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+            try {
+              new ReplicatorBuilder().pull().from(datastore).to(uri).addRequestInterceptors(null).build(function(error,
+                  replicator) {
+                expect(true).toBe(false);
+              });
+              expect(true).toBe(false);
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it("throws error if response interceptor is null", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('throws error if response interceptor is null', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(datastore).to(uri).addResponseInterceptors(null).build(function(error,
-                                replicator) {
-                                expect(true).toBe(false);
-                            });
-                            expect(true).toBe(false);
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+            try {
+              new ReplicatorBuilder().pull().from(datastore).to(uri).addResponseInterceptors(null).build(function(error,
+                  replicator) {
+                expect(true).toBe(false);
+              });
+              expect(true).toBe(false);
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it("throws error if request interceptor is empty", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('throws error if request interceptor is empty', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(datastore).to(uri).addRequestInterceptors().build(function(error,
-                                replicator) {
-                                expect(true).toBe(false);
-                            });
-                            expect(true).toBe(false);
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+            try {
+              new ReplicatorBuilder().pull().from(datastore).to(uri).addRequestInterceptors().build(function(error,
+                  replicator) {
+                expect(true).toBe(false);
+              });
+              expect(true).toBe(false);
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it("throws error if response interceptor is empty", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('throws error if response interceptor is empty', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(datastore).to(uri).addResponseInterceptors().build(function(error,
-                                replicator) {
-                                expect(true).toBe(false);
-                            });
-                            expect(true).toBe(false);
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+            try {
+              new ReplicatorBuilder().pull().from(datastore).to(uri).addResponseInterceptors().build(function(error,
+                  replicator) {
+                expect(true).toBe(false);
+              });
+              expect(true).toBe(false);
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it("throws error if request interceptor is not a function or an array", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('throws error if request interceptor is not a function or an array', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(datastore).to(uri).addRequestInterceptors("foo").build(function(error,
-                                replicator) {
-                                expect(true).toBe(false);
-                            });
-                            expect(true).toBe(false);
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+            try {
+              new ReplicatorBuilder().pull().from(datastore).to(uri).addRequestInterceptors('foo').build(function(error,
+                  replicator) {
+                expect(true).toBe(false);
+              });
+              expect(true).toBe(false);
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it("throws error if response interceptor is not a function or an array", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('throws error if response interceptor is not a function or an array', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(datastore).to(uri).addResponseInterceptors("foo").build(function(error,
-                                replicator) {
-                                expect(true).toBe(false);
-                            });
-                            expect(true).toBe(false);
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+            try {
+              new ReplicatorBuilder().pull().from(datastore).to(uri).addResponseInterceptors('foo').build(function(error,
+                  replicator) {
+                expect(true).toBe(false);
+              });
+              expect(true).toBe(false);
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it("throws error if request interceptor in an array is not a function", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('throws error if request interceptor in an array is not a function', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(datastore).to(uri).addRequestInterceptors(["foo"]).build(function(error,
-                                replicator) {
-                                expect(true).toBe(false);
-                            });
-                            expect(true).toBe(false);
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+            try {
+              new ReplicatorBuilder().pull().from(datastore).to(uri).addRequestInterceptors(['foo']).build(function(error,
+                  replicator) {
+                expect(true).toBe(false);
+              });
+              expect(true).toBe(false);
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it("throws error if response interceptor in an array is not a function", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('throws error if response interceptor in an array is not a function', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(datastore).to(uri).addResponseInterceptors(["foo"]).build(function(error,
-                                replicator) {
-                                expect(true).toBe(false);
-                            });
-                            expect(true).toBe(false);
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+            try {
+              new ReplicatorBuilder().pull().from(datastore).to(uri).addResponseInterceptors(['foo']).build(function(error,
+                  replicator) {
+                expect(true).toBe(false);
+              });
+              expect(true).toBe(false);
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it("throws error if request interceptor following a valid interceptor is not a function", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('throws error if request interceptor following a valid interceptor is not a function', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(datastore).to(uri).addRequestInterceptors(function (context) {
-                                context.done();
-                            }, "notaninterceptor").build(function(error,
-                                replicator) {
-                                expect(true).toBe(false);
-                            });
-                            expect(true).toBe(false);
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+            try {
+              new ReplicatorBuilder().pull().from(datastore).to(uri).addRequestInterceptors(function(context) {
+                context.done();
+              }, 'notaninterceptor').build(function(error,
+                  replicator) {
+                expect(true).toBe(false);
+              });
+              expect(true).toBe(false);
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it("throws error if response interceptor following a valid interceptor is not a function", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('throws error if response interceptor following a valid interceptor is not a function', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(datastore).to(uri).addResponseInterceptors(function (context) {
-                                context.done();
-                            }, "notaninterceptor").build(function(error,
-                                replicator) {
-                                expect(true).toBe(false);
-                            });
-                            expect(true).toBe(false);
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+            try {
+              new ReplicatorBuilder().pull().from(datastore).to(uri).addResponseInterceptors(function(context) {
+                context.done();
+              }, 'notaninterceptor').build(function(error,
+                  replicator) {
+                expect(true).toBe(false);
+              });
+              expect(true).toBe(false);
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                });
-                describe('Promises', function() {
-                    it("should create a pull replicator", function(done) {
-                        try {
-                            var datastore = getDatastore(storeDescription);
-                            expect(datastore).not.toBe(null);
-                            var builder = new ReplicatorBuilder();
-                            expect(builder).not.toBe(null);
+        });
+        describe('Promises', function() {
+          it('should create a pull replicator', function(done) {
+            try {
+              var datastore = getDatastore(storeDescription);
+              expect(datastore).not.toBe(null);
+              var builder = new ReplicatorBuilder();
+              expect(builder).not.toBe(null);
 
-                            builder.pull().from(uri).to(datastore).build()
+              builder.pull().from(uri).to(datastore).build()
                                 .then(function(replicator) {
-                                    expect(replicator.token).not.toBe(null);
-                                    replicator.token = badtoken; // assert readonly
-                                    expect(replicator.token).not.toBe(badtoken);
+                                  expect(replicator.token).not.toBe(null);
+                                  replicator.token = badtoken; // Assert readonly
+                                  expect(replicator.token).not.toBe(badtoken);
 
-                                    expect(replicator.type).toBe('pull');
-                                    replicator.type = badtype; // assert readonly
-                                    expect(replicator.type).not.toBe(badtype);
+                                  expect(replicator.type).toBe('pull');
+                                  replicator.type = badtype; // Assert readonly
+                                  expect(replicator.type).not.toBe(badtype);
 
-                                    expect(replicator.datastore).toBe(datastore);
-                                    replicator.datastore = baddatastore; // assert readonly
-                                    expect(replicator.datastore).not.toBe(baddatastore);
+                                  expect(replicator.datastore).toBe(datastore);
+                                  replicator.datastore = baddatastore; // Assert readonly
+                                  expect(replicator.datastore).not.toBe(baddatastore);
 
-                                    expect(replicator.uri).toBe(uri);
-                                    replicator.uri = baduri; // assert readonly
-                                    expect(replicator.uri).not.toBe(baduri);
+                                  expect(replicator.uri).toBe(uri);
+                                  replicator.uri = baduri; // Assert readonly
+                                  expect(replicator.uri).not.toBe(baduri);
                                 })
                                 .catch(function(error) {
-                                    expect(error).toBe(null);
+                                  expect(error).toBe(null);
                                 })
                                 .fin(done);
-                        } catch (e) {
-                            expect(e).toBe(null);
-                            done();
-                        }
-                    });
-                    it("should create a push replicator", function(done) {
-                        try {
-                            var datastore = getDatastore(storeDescription);
-                            expect(datastore).not.toBe(null);
-                            var builder = new ReplicatorBuilder();
-                            expect(builder).not.toBe(null);
+            } catch (e) {
+              expect(e).toBe(null);
+              done();
+            }
+          });
+          it('should create a push replicator', function(done) {
+            try {
+              var datastore = getDatastore(storeDescription);
+              expect(datastore).not.toBe(null);
+              var builder = new ReplicatorBuilder();
+              expect(builder).not.toBe(null);
 
-                            builder.push().from(datastore).to(uri).build()
+              builder.push().from(datastore).to(uri).build()
                                 .then(function(replicator) {
-                                    expect(replicator.token).not.toBe(null);
-                                    replicator.token = badtoken; // assert readonly
-                                    expect(replicator.token).not.toBe(badtoken);
+                                  expect(replicator.token).not.toBe(null);
+                                  replicator.token = badtoken; // Assert readonly
+                                  expect(replicator.token).not.toBe(badtoken);
 
-                                    expect(replicator.type).toBe('push');
-                                    replicator.type = badtype; // assert readonly
-                                    expect(replicator.type).not.toBe(badtype);
+                                  expect(replicator.type).toBe('push');
+                                  replicator.type = badtype; // Assert readonly
+                                  expect(replicator.type).not.toBe(badtype);
 
-                                    expect(replicator.datastore).toBe(datastore);
-                                    replicator.datastore = baddatastore; // assert readonly
-                                    expect(replicator.datastore).not.toBe(baddatastore);
+                                  expect(replicator.datastore).toBe(datastore);
+                                  replicator.datastore = baddatastore; // Assert readonly
+                                  expect(replicator.datastore).not.toBe(baddatastore);
 
-                                    expect(replicator.uri).toBe(uri);
-                                    replicator.uri = baduri; // assert readonly
-                                    expect(replicator.uri).not.toBe(baduri);
+                                  expect(replicator.uri).toBe(uri);
+                                  replicator.uri = baduri; // Assert readonly
+                                  expect(replicator.uri).not.toBe(baduri);
                                 })
                                 .catch(function(error) {
-                                    expect(error).toBe(null);
+                                  expect(error).toBe(null);
                                 })
                                 .fin(done);
-                        } catch (e) {
-                            expect(e).toBe(null);
-                            done();
-                        }
-                    });
+            } catch (e) {
+              expect(e).toBe(null);
+              done();
+            }
+          });
 
-                    it('should create two replicators with different tokens', function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('should create two replicators with different tokens', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        var promises = [
-                            new ReplicatorBuilder().pull().to(datastore).from(uri).build(),
-                            new ReplicatorBuilder().push().from(datastore).to(uri).build()
-                        ];
+            var promises = [
+                new ReplicatorBuilder().pull().to(datastore).from(uri).build(),
+                new ReplicatorBuilder().push().from(datastore).to(uri).build(),
+            ];
 
-                        Q.all(promises)
+            Q.all(promises)
                             .spread(function(pullReplicator, pushReplicator) {
-                                expect(pullReplicator.token).not.toEqual(pushReplicator.token);
+                              expect(pullReplicator.token).not.toEqual(pushReplicator.token);
                             })
                             .catch(function(error) {
-                                expect(error).toBe(null);
+                              expect(error).toBe(null);
                             })
                             .fin(done);
-                    });
+          });
 
-                    // negative tests
-                    it("throws error if push source is null", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          // Negative tests
+          it('throws error if push source is null', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().push().from(null).to(uri).build()
+            try {
+              new ReplicatorBuilder().push().from(null).to(uri).build()
                                 .then(function(replicator) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 })
                                 .catch(function(e) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 });
-                            expect(true).toBe(false);
-                            done();
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
-                    it("throws error if push target is null", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
+          it('throws error if push target is null', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().push().from(datastore).to(null).build()
+            try {
+              new ReplicatorBuilder().push().from(datastore).to(null).build()
                                 .then(function(replicator) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 })
                                 .catch(function(e) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 });
-                            expect(true).toBe(false);
-                            done();
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
-                    it("throws error if pull source is null", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
+          it('throws error if pull source is null', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(null).to(datastore).build()
+            try {
+              new ReplicatorBuilder().pull().from(null).to(datastore).build()
                                 .then(function(replicator) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 })
                                 .catch(function(e) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 });
-                            expect(true).toBe(false);
-                            done();
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
-                    it("throws error if pull target is null", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
+          it('throws error if pull target is null', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(uri).to(null).build()
+            try {
+              new ReplicatorBuilder().pull().from(uri).to(null).build()
                                 .then(function(replicator) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 })
                                 .catch(function(e) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 });
-                            expect(true).toBe(false);
-                            done();
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it("throws error if pull source is not a String", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('throws error if pull source is not a String', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from([]).to(datastore).build()
+            try {
+              new ReplicatorBuilder().pull().from([]).to(datastore).build()
                                 .then(function(replicator) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 })
                                 .catch(function(e) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 });
-                            expect(true).toBe(false);
-                            done();
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
-                    it("throws error if pull target is not a Datastore", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
+          it('throws error if pull target is not a Datastore', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(uri).to([]).build()
+            try {
+              new ReplicatorBuilder().pull().from(uri).to([]).build()
                                 .then(function(replicator) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 })
                                 .catch(function(e) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 });
-                            expect(true).toBe(false);
-                            done();
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it("throws error if push source is not a Datastore", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('throws error if push source is not a Datastore', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().push().from([]).to(uri).build()
+            try {
+              new ReplicatorBuilder().push().from([]).to(uri).build()
                                 .then(function(replicator) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 })
                                 .catch(function(e) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 });
-                            expect(true).toBe(false);
-                            done();
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
-                    it("throws error if push target is not a String", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
+          it('throws error if push target is not a String', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().push().from(datastore).to([]).build()
+            try {
+              new ReplicatorBuilder().push().from(datastore).to([]).build()
                                 .then(function(replicator) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 })
                                 .catch(function(e) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 });
-                            expect(true).toBe(false);
-                            done();
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it("throws error if push target is not set", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('throws error if push target is not set', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().push().from(datastore).build()
+            try {
+              new ReplicatorBuilder().push().from(datastore).build()
                                 .then(function(replicator) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 })
                                 .catch(function(e) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 });
-                            expect(true).toBe(false);
-                            done();
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
-                    it("throws error if pull target is not set", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
+          it('throws error if pull target is not set', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(uri).build()
+            try {
+              new ReplicatorBuilder().pull().from(uri).build()
                                 .then(function(replicator) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 })
                                 .catch(function(e) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 });
-                            expect(true).toBe(false);
-                            done();
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
-                    it("throws error if push source is not set", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
+          it('throws error if push source is not set', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().push().to(uri).build()
+            try {
+              new ReplicatorBuilder().push().to(uri).build()
                                 .then(function(replicator) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 })
                                 .catch(function(e) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 });
-                            expect(true).toBe(false);
-                            done();
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
-                    it("throws error if pull target is not set", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
+          it('throws error if pull target is not set', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().to(datastore).build()
+            try {
+              new ReplicatorBuilder().pull().to(datastore).build()
                                 .then(function(replicator) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 })
                                 .catch(function(e) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 });
-                            expect(true).toBe(false);
-                            done();
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
-                    it("throws error if replication type is not set", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
+          it('throws error if replication type is not set', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().from(datastore).to(uri).build()
+            try {
+              new ReplicatorBuilder().from(datastore).to(uri).build()
                                 .then(function(replicator) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 })
                                 .catch(function(e) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 });
-                            expect(true).toBe(false);
-                            done();
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it("throws error if pull target is not set", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('throws error if pull target is not set', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().to(datastore).build()
+            try {
+              new ReplicatorBuilder().pull().to(datastore).build()
                                 .then(function(replicator) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 })
                                 .catch(function(e) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 });
-                            expect(true).toBe(false);
-                            done();
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it("throws error if request interceptor is null", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('throws error if request interceptor is null', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(datastore).to(uri).addRequestInterceptors(null).build()
+            try {
+              new ReplicatorBuilder().pull().from(datastore).to(uri).addRequestInterceptors(null).build()
                                 .then(function(replicator) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 })
                                 .catch(function(e) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 });
-                            expect(true).toBe(false);
-                            done();
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it("throws error if response interceptor is null", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('throws error if response interceptor is null', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(datastore).to(uri).addResponseInterceptors(null).build()
+            try {
+              new ReplicatorBuilder().pull().from(datastore).to(uri).addResponseInterceptors(null).build()
                                 .then(function(replicator) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 })
                                 .catch(function(e) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 });
-                            expect(true).toBe(false);
-                            done();
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it("throws error if request interceptor is empty", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('throws error if request interceptor is empty', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(datastore).to(uri).addRequestInterceptors().build()
+            try {
+              new ReplicatorBuilder().pull().from(datastore).to(uri).addRequestInterceptors().build()
                                 .then(function(replicator) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 })
                                 .catch(function(e) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 });
-                            expect(true).toBe(false);
-                            done();
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it("throws error if response interceptor is empty", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('throws error if response interceptor is empty', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(datastore).to(uri).addResponseInterceptors().build()
+            try {
+              new ReplicatorBuilder().pull().from(datastore).to(uri).addResponseInterceptors().build()
                                 .then(function(replicator) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 })
                                 .catch(function(e) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 });
-                            expect(true).toBe(false);
-                            done();
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it("throws error if request interceptor is not a function or an array", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('throws error if request interceptor is not a function or an array', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(datastore).to(uri).addRequestInterceptors("foo").build()
+            try {
+              new ReplicatorBuilder().pull().from(datastore).to(uri).addRequestInterceptors('foo').build()
                                 .then(function(replicator) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 })
                                 .catch(function(e) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 });
-                            expect(true).toBe(false);
-                            done();
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it("throws error if response interceptor is not a function or an array", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('throws error if response interceptor is not a function or an array', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(datastore).to(uri).addResponseInterceptors("foo").build()
+            try {
+              new ReplicatorBuilder().pull().from(datastore).to(uri).addResponseInterceptors('foo').build()
                                 .then(function(replicator) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 })
                                 .catch(function(e) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 });
-                            expect(true).toBe(false);
-                            done();
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it("throws error if request interceptor in an array is not a function", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('throws error if request interceptor in an array is not a function', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(datastore).to(uri).addRequestInterceptors(["foo"]).build()
+            try {
+              new ReplicatorBuilder().pull().from(datastore).to(uri).addRequestInterceptors(['foo']).build()
                                 .then(function(replicator) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 })
                                 .catch(function(e) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 });
-                            expect(true).toBe(false);
-                            done();
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it("throws error if response interceptor in an array is not a function", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('throws error if response interceptor in an array is not a function', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(datastore).to(uri).addResponseInterceptors(["foo"]).build()
+            try {
+              new ReplicatorBuilder().pull().from(datastore).to(uri).addResponseInterceptors(['foo']).build()
                                 .then(function(replicator) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 })
                                 .catch(function(e) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 });
-                            expect(true).toBe(false);
-                            done();
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it("throws error if request interceptor following a valid interceptor is not a function", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('throws error if request interceptor following a valid interceptor is not a function', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(datastore).to(uri).addRequestInterceptors(function (context) {
-                                context.done();
-                            }, "notaninterceptor").build()
+            try {
+              new ReplicatorBuilder().pull().from(datastore).to(uri).addRequestInterceptors(function(context) {
+                context.done();
+              }, 'notaninterceptor').build()
                                 .then(function(replicator) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 })
                                 .catch(function(e) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 });
-                            expect(true).toBe(false);
-                            done();
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
 
-                    it("throws error if response interceptor following a valid interceptor is not a function", function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
+          it('throws error if response interceptor following a valid interceptor is not a function', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
 
-                        try {
-                            new ReplicatorBuilder().pull().from(datastore).to(uri).addResponseInterceptors(function (context) {
-                                context.done();
-                            }, "notaninterceptor").build()
+            try {
+              new ReplicatorBuilder().pull().from(datastore).to(uri).addResponseInterceptors(function(context) {
+                context.done();
+              }, 'notaninterceptor').build()
                                 .then(function(replicator) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 })
                                 .catch(function(e) {
-                                    expect(true).toBe(false);
+                                  expect(true).toBe(false);
                                 });
-                            expect(true).toBe(false);
-                            done();
-                        } catch (error) {
-                            expect(error).not.toBe(null);
-                            done();
-                        }
-                    });
-                });
-            });
-
-            describe('Replicator (' + storeDescription + ')', function() {
-
-                var testPullReplicator;
-                var testPushReplicator;
-
-                function getReplicator(type) {
-                    var rep;
-                    switch (type) {
-                        case 'pull':
-                            rep = testPullReplicator;
-                            break;
-                        case 'push':
-                            rep = testPushReplicator;
-                            break;
-                    }
-                    return rep;
-                }
-
-                beforeEach(function(done) {
-                    jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
-                    var datastore = getDatastore(storeDescription);
-                    expect(datastore).not.toBe(null);
-
-                    new ReplicatorBuilder().pull().from(uri).to(datastore).build()
-                        .then(function(pullReplicator) {
-                            expect(pullReplicator).not.toBe(null);
-                            testPullReplicator = pullReplicator;
-
-                            return new ReplicatorBuilder().push().from(datastore).to(uri).build();
-                        })
-                        .then(function(pushReplicator) {
-                            expect(pushReplicator).not.toBe(null);
-                            testPushReplicator = pushReplicator;
-                        })
-                        .catch(function(error) {
-                            expect(error).toBe(null);
-                        })
-                        .fin(done);
-                });
-
-                it('should contain method start', function() {
-                    var pullReplicator = getReplicator('pull');
-                    expect(pullReplicator).not.toBe(null);
-                    var pushReplicator = getReplicator('push');
-                    expect(pushReplicator).not.toBe(null);
-
-                    expect(pullReplicator.start).toBeDefined();
-                    expect(pushReplicator.start).toBeDefined();
-                });
-
-
-
-                it('should contain method getState', function() {
-                    var pullReplicator = getReplicator('pull');
-                    expect(pullReplicator).not.toBe(null);
-                    var pushReplicator = getReplicator('push');
-                    expect(pushReplicator).not.toBe(null);
-
-                    expect(pullReplicator.getState).toBeDefined();
-                    expect(pushReplicator.getState).toBeDefined();
-                });
-
-                it('should contain method stop', function() {
-                    var pullReplicator = getReplicator('pull');
-                    expect(pullReplicator).not.toBe(null);
-                    var pushReplicator = getReplicator('push');
-                    expect(pushReplicator).not.toBe(null);
-
-                    expect(pullReplicator.stop).toBeDefined();
-                    expect(pushReplicator.stop).toBeDefined();
-                });
-
-                describe('.start([callback])', function() {
-
-                    describe('Callbacks', function() {
-
-                        it("should start pull replication", function(done) {
-                            var replicator = getReplicator('pull');
-                            expect(replicator).not.toBe(null);
-
-                            // start replication
-                            replicator.start(function(error) {
-                                expect(error).toBe(null);
-                                done();
-                            });
-                        });
-
-                        it('should start push replication', function(done) {
-                            var replicator = getReplicator('push');
-                            expect(replicator).not.toBe(null);
-
-                            // start replication
-                            replicator.start(function(error) {
-                                expect(error).toBe(null);
-                                done();
-                            });
-                        });
-                    }); // end-callbacks-tests
-
-                    describe('Promises', function() {
-
-                        it("should start pull replication", function(done) {
-                            var replicator = getReplicator('pull');
-                            expect(replicator).not.toBe(null);
-
-                            replicator.start()
-                                .then(function() {
-                                    expect(true).toBe(true);
-                                })
-                                .catch(function(error) {
-                                    expect(error).toBe(null);
-                                })
-                                .fin(done);
-                        });
-
-                        it("should start push replication", function(done) {
-                            var replicator = getReplicator('push');
-                            expect(replicator).not.toBe(null);
-
-                            // start replication
-                            replicator.start()
-                                .then(function() {
-                                    expect(true).toBe(true);
-                                })
-                                .catch(function(error) {
-                                    expect(error).toBe(null);
-                                })
-                                .fin(done);
-                        });
-                    }); // end-promises-tests
-
-                }); // end-start-tests
-
-                describe('.getState([callback])', function() {
-
-                    describe('Callbacks', function() {
-
-                        it("should poll pull replication status until completion", function(done) {
-                            var replicator = getReplicator('pull');
-                            expect(replicator).not.toBe(null);
-
-                            var mtimer;
-
-                            function poll(replicator) {
-                                mtimer = setInterval(function() {
-                                    replicator.getState(function(error,
-                                        result) {
-                                        expect(error).toBe(null);
-                                        if (result === 'Complete') {
-                                            stopPoll();
-                                            done();
-                                        }
-                                    });
-                                }, 500);
-                            }
-
-                            function stopPoll() {
-                                clearInterval(mtimer);
-                            }
-
-                            // start replication
-                            replicator.start(function(error) {
-                                expect(error).toBe(null);
-                                poll(replicator); // poll on the replication status
-                            });
-                        });
-
-                        it("should poll push replication status until completion", function(done) {
-                            var replicator = getReplicator('push');
-                            expect(replicator).not.toBe(null);
-
-                            var mtimer;
-
-                            function poll(replicator) {
-                                mtimer = setInterval(function() {
-                                    replicator.getState(function(error,
-                                        result) {
-                                        expect(error).toBe(null);
-                                        if (result === 'Complete') {
-                                            stopPoll();
-                                            done();
-                                        }
-                                    });
-                                }, 500);
-                            }
-
-                            function stopPoll() {
-                                clearInterval(mtimer);
-                            }
-
-                            // start replication
-                            replicator.start(function(error) {
-                                expect(error).toBe(null);
-                                poll(replicator); // poll on the replication status
-                            });
-                        });
-
-                        it("should poll two replication's status until completion", function(done) {
-                            var pullReplicator = getReplicator('pull');
-                            expect(pullReplicator).not.toBe(null);
-                            var pushReplicator = getReplicator('push');
-                            expect(pushReplicator).not.toBe(null);
-
-                            var mtimer1, mtimer2;
-                            var ncompletions = 0;
-
-                            function poll(rep) {
-                                return setInterval(repStatus, 2000, rep);
-                            }
-
-                            var repStatus = function(rep) {
-                                rep.getState(function(error,
-                                    result) {
-                                    if (result ===
-                                        'Complete') {
-                                        ncompletions++;
-                                    }
-                                    if (ncompletions > 1) {
-                                        stopPoll();
-                                        done();
-                                    }
-                                });
-                            };
-
-                            function stopPoll() {
-                                clearInterval(mtimer1);
-                                clearInterval(mtimer2);
-                            }
-
-                            // start replications
-                            pullReplicator.start(function(error) {
-                                expect(error).toBe(null);
-                                // start polling on replication status
-                                mtimer1 = poll(pullReplicator);
-                            });
-                            pushReplicator.start(function(error) {
-                                expect(error).toBe(null);
-                                mtimer2 = poll(pushReplicator);
-                            });
-                        });
-                    }); // end-callbacks-tests
-
-                    describe('Promises', function() {
-
-                        it("should poll pull replication status until completion", function(done) {
-                            var replicator = getReplicator('pull');
-                            expect(replicator).not.toBe(null);
-
-                            var mtimer;
-
-                            function poll(replicator) {
-                                mtimer = setInterval(function() {
-                                    replicator.getState()
-                                        .then(function(result) {
-                                            expect(result).not.toBe(null);
-                                            if (result === 'Complete') {
-                                                stopPoll();
-                                                done();
-                                            }
-                                        })
-                                        .catch(function(error) {
-                                            expect(error).toBe(null);
-                                        });
-                                }, 500);
-                            }
-
-                            function stopPoll() {
-                                clearInterval(mtimer);
-                            }
-
-                            // start replication
-                            replicator.start()
-                                .then(function() {
-                                    poll(replicator); // poll on the replication status
-                                })
-                                .catch(function(error) {
-                                    expect(error).toBe(null);
-                                });
-                        });
-
-                        it("should poll push replication status until completion", function(done) {
-                            var replicator = getReplicator('push');
-                            expect(replicator).not.toBe(null);
-
-                            var mtimer;
-
-                            function poll(replicator) {
-                                mtimer = setInterval(function() {
-                                    replicator.getState()
-                                        .then(function(result) {
-                                            expect(result).not.toBe(null);
-                                            if (result === 'Complete') {
-                                                stopPoll();
-                                                done();
-                                            }
-                                        })
-                                        .catch(function(error) {
-                                            expect(error).toBe(null);
-                                        });
-                                }, 500);
-                            }
-
-                            function stopPoll() {
-                                clearInterval(mtimer);
-                            }
-
-                            replicator.start()
-                                .then(function() {
-                                    poll(replicator); // poll on the replication status
-                                })
-                                .catch(function(error) {
-                                    expect(error).toBe(null);
-                                });
-                        });
-
-                        it("should poll two replication's status until completion", function(done) {
-                            var pullReplicator = getReplicator('pull');
-                            expect(pullReplicator).not.toBe(null);
-                            var pushReplicator = getReplicator('push');
-                            expect(pushReplicator).not.toBe(null);
-
-                            var mtimer1, mtimer2;
-                            var ncompletions = 0;
-
-                            function poll(rep) {
-                                return setInterval(repStatus, 2000, rep);
-                            }
-
-                            var repStatus = function(rep) {
-                                rep.getState()
-                                    .then(function(result) {
-                                        if (result === 'Complete') {
-                                            ncompletions++;
-                                        }
-                                        if (ncompletions > 1) {
-                                            stopPoll();
-                                            done();
-                                        }
-                                    })
-                                    .catch(function(error) {
-                                        expect(error).not.toBe(null);
-                                    });
-                            };
-
-                            function stopPoll() {
-                                clearInterval(mtimer1);
-                                clearInterval(mtimer2);
-                            }
-
-                            // start replicators
-                            Q.all([pullReplicator.start(), pushReplicator.start()])
-                                .then(function() {
-                                    // start polling on replication status
-                                    mtimer1 = poll(pullReplicator);
-                                    mtimer2 = poll(pushReplicator);
-                                })
-                                .catch(function(error) {
-                                    expect(error).toBe(null);
-                                });
-                        });
-                    }); // end-promises-tests
-
-                }); // end-getState-tests
-
-                describe('.stop([callback])', function() {
-
-                    describe('Callbacks', function() {
-
-                        it('should stop pull replication', function(done) {
-                            var replicator = getReplicator('pull');
-                            expect(replicator).not.toBe(null);
-
-                            // start replication
-                            replicator.start(function(error) {
-                                expect(error).toBe(null);
-                                replicator.stop(function(error) {
-                                    expect(error).toBe(null);
-                                    done();
-                                });
-                            });
-                        });
-
-                        it('should stop push replication', function(done) {
-                            var replicator = getReplicator('push');
-                            expect(replicator).not.toBe(null);
-
-                            // start replication
-                            replicator.start(function(error) {
-                                expect(error).toBe(null);
-                                replicator.stop(function(error) {
-                                    expect(error).toBe(null);
-                                    done();
-                                });
-                            });
-                        });
-                    }); // end-callbacks-tests
-
-                    describe('Promises', function() {
-
-                        it('should stop pull replication', function(done) {
-                            var replicator = getReplicator('pull');
-                            expect(replicator).not.toBe(null);
-
-                            // start replication
-                            replicator.start()
-                                .then(function() {
-                                    return replicator.stop();
-                                })
-                                .catch(function(error) {
-                                    expect(error).toBe(null);
-                                })
-                                .fin(done);
-                        });
-
-                        it('should stop push replication', function(done) {
-                            var replicator = getReplicator('pull');
-                            expect(replicator).not.toBe(null);
-
-                            // start replication
-                            replicator.start()
-                                .then(function() {
-                                    return replicator.stop();
-                                })
-                                .catch(function(error) {
-                                    expect(error).toBe(null);
-                                })
-                                .fin(done);
-                        });
-                    }); // end-promises-tests
-                }); // end-stop-tests
-
-                describe('.on(event, handler)', function() {
-                    it('should register and fire a "complete" event', function(done) {
-                        var replicator = getReplicator('pull');
-                        expect(replicator).not.toBe(null);
-
-                        replicator.on('complete', function(numDocs) {
-                            expect(numDocs).not.toBe(null);
-                            done();
-                        });
-
-                        replicator.start()
-                            .catch(function(error) {
-                                expect(error).toBe(null);
-                            });
-                    });
-
-                    it('should register and fire an "error" event', function(done) {
-                        var datastore = getDatastore(storeDescription);
-                        expect(datastore).not.toBe(null);
-
-                        new ReplicatorBuilder().pull().to(datastore).from(uri + 'foo').build()
-                            .then(function(replicator) {
-                                expect(replicator).not.toBe(null);
-                                replicator.on('error', function(message) {
-                                    expect(message).not.toBe(null);
-                                    done();
-                                });
-
-                                return replicator.start();
-                            })
-                            .catch(function(error) {
-                                expect(error).toBe(null);
-                            });
-                    });
-                });
-
-                describe('.destroy([callback])', function () {
-                    describe('Callbacks', function () {
-                        it('should destroy a replicator', function (done) {
-                            try{
-                                var replicator = getReplicator('pull');
-                                expect(replicator).not.toBe(null);
-                                expect(replicator.destroyed).not.toBeDefined();
-
-                                replicator.destroy(function (error) {
-                                    try {
-                                        expect(error).toBe(null);
-                                        expect(replicator.destroyed).toBe(true);
-                                        done();
-                                    } catch(e){
-                                        expect(e).toBe(null);
-                                        done();
-                                    }
-                                });
-                            } catch (e){
-                                expect(e).toBe(null);
-                                done();
-                            }
-                        });
-                    });
-
-                    describe('Promises', function () {
-                        it('should destroy a replicator', function (done) {
-                            try {
-                                var replicator = getReplicator('pull');
-                                expect(replicator).not.toBe(null);
-                                expect(replicator.destroyed).not.toBeDefined();
-
-                                replicator.destroy()
-                                    .then(function () {
-                                        expect(replicator.destroyed).toBe(true);
-                                    })
-                                    .catch(function (error) {
-                                        expect(error).toBe(null);
-                                    })
-                                    .fin(done);
-                            } catch(e){
-                                expect(e).toBe(null);
-                                done();
-                            }
-                        });
-                    });
-                });
-
-                describe('pull replication', function() {
-                    it('should pull documents from animaldb', function(done) {
-                        var replicator = getReplicator('pull');
-                        expect(replicator).not.toBe(null);
-
-                        replicator.on('complete', function(numDocs) {
-                            expect(numDocs).not.toBe(null);
-
-                            replicator.datastore.getDocument('aardvark')
-                                .then(function(documentRevision) {
-                                    expect(documentRevision).not.toBe(null);
-                                    expect(documentRevision._id).not.toBe(null);
-                                    expect(documentRevision._id).toBe('aardvark');
-                                    done();
-                                });
-                        });
-
-                        replicator.start()
-                            .catch(function(error) {
-                                expect(error).toBe(null);
-                            });
-                    });
-                });
-
-                describe('push replication', function() {
-                    it('should push documents to testdb', function(done) {
-                        try {
-                            var pushReplicator = getReplicator('push');
-                            expect(pushReplicator).not.toBe(null);
-
-                            var pullReplicator = getReplicator('pull');
-                            expect(pullReplicator).not.toBe(null);
-
-                            pullReplicator.on('complete', function (numDocs) {
-                                expect(numDocs).not.toBe(null);
-                            });
-
-                            pullReplicator.on('error', function(message) {
-                                expect(message).toBe(null);
-                                done();
-                            });
-
-                            pushReplicator.on('complete', function(numDocs) {
-                                expect(numDocs).not.toBe(null);
-                                expect(numDocs).toBe(1);
-                                done();
-                            });
-
-                            pushReplicator.on('error', function(message) {
-                                expect(message).toBe(null);
-                                done();
-                            });
-
-                            pullReplicator.on('complete',function (numDocs) {
-                                pushReplicator.datastore.createDocumentFromRevision({
-                                        foo: 'bar'
-                                    })
-                                    .then(function(savedRevision) {
-                                        expect(savedRevision).not.toBe(null);
-
-                                        return pushReplicator.start();
-                                    })
-                                    .catch(function(error) {
-                                        expect(error).toBe(null);
-                                        done();
-                                    });
-                            });
-
-                            pullReplicator.start()
-                                .catch(function (e) {
-                                    expect(e).toBe(null);
-                                });
-                        } catch (e) {
-                            console.log(e);
-                            done();
-                        }
-                    });
-                });
-
-                describe('interceptors', function () {
-                    it('should add a request header', function (done) {
-                        var datastore = getDatastore(storeDescription);
-
-                        new ReplicatorBuilder()
-                            .pull()
-                            .from(uri)
-                            .to(datastore)
-                            .addRequestInterceptors(function (context) {
-                                expect(context).not.toBe(null);
-                                expect(context.request).toBeDefined();
-                                expect(context.request).not.toBe(null);
-                                expect(context.request.headers).toBeDefined();
-                                expect(context.request.headers).not.toBe(null);
-                                expect(context.request.url).toBeDefined();
-                                expect(context.request.url).not.toBe(null);
-
-                                expect(context.response).toBeDefined();
-                                expect(context.response).toBe(null);
-
-                                expect(context.replayRequest).toBeDefined();
-                                expect(context.replayRequest).not.toBe(null);
-
-                                context.request.headers['x-my-foo-header'] = 'bar';
-                                context.done();
-                            })
-                            .addResponseInterceptors(function (context) {
-                                expect(context).not.toBe(null);
-                                expect(context.request).toBeDefined();
-                                expect(context.request).not.toBe(null);
-                                expect(context.request.headers).toBeDefined();
-                                expect(context.request.headers).not.toBe(null);
-                                expect(context.request.headers['x-my-foo-header']).toBeDefined();
-                                expect(context.request.headers['x-my-foo-header']).toBe('bar');
-                                expect(context.request.url).toBeDefined();
-                                expect(context.request.url).not.toBe(null);
-
-                                expect(context.response).toBeDefined();
-                                expect(context.response).not.toBe(null);
-                                expect(context.response.statusCode).toBeDefined();
-                                expect(context.response.statusCode).not.toBe(null);
-                                expect(context.response.headers).toBeDefined();
-                                expect(context.response.headers).not.toBe(null);
-
-                                expect(context.replayRequest).toBeDefined();
-                                expect(context.replayRequest).not.toBe(null);
-
-                                context.done();
-
-                            }).build()
-                                .then(function (replicator) {
-                                    expect(replicator).not.toBe(null);
-
-                                    replicator.on('complete', function(numDocs) {
-                                        expect(numDocs).not.toBe(null);
-
-                                        replicator.datastore.getDocument('aardvark')
-                                            .then(function(documentRevision) {
-                                                expect(documentRevision).not.toBe(null);
-                                                expect(documentRevision._id).not.toBe(null);
-                                                expect(documentRevision._id).toBe('aardvark');
-                                                done();
-                                            });
-                                    });
-
-                                    return replicator.start();
-                                })
-                                .catch(function (error) {
-                                    expect(error).toBe(null);
-                                    done();
-                                });
-                    });
-
-                    it('should timeout', function (done) {
-                        var datastore = getDatastore(storeDescription);
-
-                        new ReplicatorBuilder()
-                            .pull()
-                            .from(uri)
-                            .to(datastore)
-                            .addRequestInterceptors(function (context) {
-                                expect(context).not.toBe(null);
-                                expect(context.request).toBeDefined();
-                                expect(context.request).not.toBe(null);
-                                expect(context.request.headers).toBeDefined();
-                                expect(context.request.headers).not.toBe(null);
-
-                                context.request.headers['x-my-foo-header'] = 'bar';
-                                // NOT calling context.done() to force a timeout
-                            })
-                            .addResponseInterceptors(function (context) {
-                                expect(context).not.toBe(null);
-                                expect(context.request).toBeDefined();
-                                expect(context.request).not.toBe(null);
-                                expect(context.request.headers).toBeDefined();
-                                expect(context.request.headers).not.toBe(null);
-                                expect(context.request.headers['x-my-foo-header']).not.toBeDefined();
-
-                                context.done();
-
-                            }).build()
-                                .then(function (replicator) {
-                                    expect(replicator).not.toBe(null);
-
-                                    // Shortening the timeout duration
-                                    replicator.interceptors.timeout = 5000;
-
-                                    replicator.on('complete', function(numDocs) {
-                                        expect(numDocs).not.toBe(null);
-
-                                        replicator.datastore.getDocument('aardvark')
-                                            .then(function(documentRevision) {
-                                                expect(documentRevision).not.toBe(null);
-                                                expect(documentRevision._id).not.toBe(null);
-                                                expect(documentRevision._id).toBe('aardvark');
-                                                done();
-                                            });
-                                    });
-
-                                    return replicator.start();
-                                })
-                                .catch(function (error) {
-                                    expect(error).toBe(null);
-                                    done();
-                                });
-                    });
-
-                    it('should execute two interceptors', function (done) {
-                        var datastore = getDatastore(storeDescription);
-
-                        var reqInterceptor1 = function (context) {
-                            expect(context).not.toBe(null);
-                            expect(context.request).toBeDefined();
-                            expect(context.request).not.toBe(null);
-                            expect(context.request.headers).toBeDefined();
-                            expect(context.request.headers).not.toBe(null);
-
-                            context.request.headers['x-my-foo-header'] = 'bar';
-                            context.done();
-                        };
-
-                        var reqInterceptor2 = function (context) {
-                            expect(context).not.toBe(null);
-                            expect(context.request).toBeDefined();
-                            expect(context.request).not.toBe(null);
-                            expect(context.request.headers).toBeDefined();
-                            expect(context.request.headers).not.toBe(null);
-
-                            context.request.headers['x-my-bar-header'] = 'foo';
-                            context.done();
-                        };
-
-                        var resInterceptor1 = function (context) {
-                            expect(context).not.toBe(null);
-                            expect(context.request).toBeDefined();
-                            expect(context.request).not.toBe(null);
-                            expect(context.request.headers).toBeDefined();
-                            expect(context.request.headers).not.toBe(null);
-                            expect(context.request.headers['x-my-foo-header']).toBeDefined();
-                            expect(context.request.headers['x-my-foo-header']).toBe('bar');
-
-                            context.done();
-                        };
-
-                        var resInterceptor2 = function (context) {
-                            expect(context).not.toBe(null);
-                            expect(context.request).toBeDefined();
-                            expect(context.request).not.toBe(null);
-                            expect(context.request.headers).toBeDefined();
-                            expect(context.request.headers).not.toBe(null);
-                            expect(context.request.headers['x-my-bar-header']).toBeDefined();
-                            expect(context.request.headers['x-my-bar-header']).toBe('foo');
-
-                            context.done();
-                        };
-
-                        new ReplicatorBuilder()
-                            .pull()
-                            .from(uri)
-                            .to(datastore)
-                            .addRequestInterceptors(reqInterceptor1, reqInterceptor2)
-                            .addResponseInterceptors(resInterceptor1, resInterceptor2).build()
-                                .then(function (replicator) {
-                                    expect(replicator).not.toBe(null);
-
-                                    // Shortening the timeout duration
-                                    replicator.interceptors.timeout = 5000;
-
-                                    replicator.on('complete', function(numDocs) {
-                                        expect(numDocs).not.toBe(null);
-
-                                        replicator.datastore.getDocument('aardvark')
-                                            .then(function(documentRevision) {
-                                                expect(documentRevision).not.toBe(null);
-                                                expect(documentRevision._id).not.toBe(null);
-                                                expect(documentRevision._id).toBe('aardvark');
-                                                done();
-                                            });
-                                    });
-
-                                    return replicator.start();
-                                })
-                                .catch(function (error) {
-                                    expect(error).toBe(null);
-                                    done();
-                                });
-                    });
-
-                    it('should set the replay flag', function (done) {
-                        var datastore = getDatastore(storeDescription);
-
-                        var numTries = 0;
-                        var url = null;
-                        new ReplicatorBuilder()
-                            .pull()
-                            .from(uri+'doesnotexist')
-                            .to(datastore)
-                            .addRequestInterceptors(function (context) {
-                                expect(context).not.toBe(null);
-                                expect(context.request).toBeDefined();
-                                expect(context.request).not.toBe(null);
-                                expect(context.request.url).toBeDefined();
-                                expect(context.request.url).not.toBe(null);
-
-                                // capture the first request url
-                                if (!url){
-                                    url = context.request.url;
-                                }
-
-                                context.done();
-                            })
-                            .addResponseInterceptors(function (context) {
-
-                                expect(context).not.toBe(null);
-                                expect(context.request).toBeDefined();
-                                expect(context.request).not.toBe(null);
-                                expect(context.request.url).toBeDefined();
-                                expect(context.request.url).not.toBe(null);
-                                expect(context.response.statusCode).toBeDefined();
-                                expect(context.response.statusCode).not.toBe(null);
-                                expect(context.replayRequest).toBeDefined();
-                                expect(context.replayRequest).not.toBe(null);
-
-                                // Tick up the number of times the first request has been sent
-                                if (context.request.url === url){
-                                    numTries++;
-
-                                    // If the url has only been requested once try again
-                                    if (context.response.statusCode === 404 && numTries < 2){
-                                        context.replayRequest = true;
-                                    }
-                                }
-
-                                context.done();
-
-                            }).build()
-                                .then(function (replicator) {
-                                    expect(replicator).not.toBe(null);
-
-                                    replicator.on('error', function (error) {
-                                        expect(error).not.toBe(null);
-                                        expect(numTries).toBe(2);
-                                        done();
-                                    });
-
-                                    return replicator.start();
-                                })
-                                .catch(function (error) {
-                                    expect(error).toBe(null);
-                                    done();
-                                });
-                    });
-                });
-            }); // end-Replicator-tests
+              expect(true).toBe(false);
+              done();
+            } catch (error) {
+              expect(error).not.toBe(null);
+              done();
+            }
+          });
+        });
+      });
+
+      describe('Replicator (' + storeDescription + ')', function() {
+
+        var testPullReplicator;
+        var testPushReplicator;
+
+        function getReplicator(type) {
+          var rep;
+          switch (type) {
+            case 'pull':
+              rep = testPullReplicator;
+              break;
+            case 'push':
+              rep = testPushReplicator;
+              break;
+          }
+          return rep;
         }
 
-        testReplication("local");
-    });
+        beforeEach(function(done) {
+          jasmine.DEFAULT_TIMEOUT_INTERVAL = 20000;
+          var datastore = getDatastore(storeDescription);
+          expect(datastore).not.toBe(null);
+
+          new ReplicatorBuilder().pull().from(uri).to(datastore).build()
+                        .then(function(pullReplicator) {
+                          expect(pullReplicator).not.toBe(null);
+                          testPullReplicator = pullReplicator;
+
+                          return new ReplicatorBuilder().push().from(datastore).to(uri).build();
+                        })
+                        .then(function(pushReplicator) {
+                          expect(pushReplicator).not.toBe(null);
+                          testPushReplicator = pushReplicator;
+                        })
+                        .catch(function(error) {
+                          expect(error).toBe(null);
+                        })
+                        .fin(done);
+        });
+
+        it('should contain method start', function() {
+          var pullReplicator = getReplicator('pull');
+          expect(pullReplicator).not.toBe(null);
+          var pushReplicator = getReplicator('push');
+          expect(pushReplicator).not.toBe(null);
+
+          expect(pullReplicator.start).toBeDefined();
+          expect(pushReplicator.start).toBeDefined();
+        });
+
+
+
+        it('should contain method getState', function() {
+          var pullReplicator = getReplicator('pull');
+          expect(pullReplicator).not.toBe(null);
+          var pushReplicator = getReplicator('push');
+          expect(pushReplicator).not.toBe(null);
+
+          expect(pullReplicator.getState).toBeDefined();
+          expect(pushReplicator.getState).toBeDefined();
+        });
+
+        it('should contain method stop', function() {
+          var pullReplicator = getReplicator('pull');
+          expect(pullReplicator).not.toBe(null);
+          var pushReplicator = getReplicator('push');
+          expect(pushReplicator).not.toBe(null);
+
+          expect(pullReplicator.stop).toBeDefined();
+          expect(pushReplicator.stop).toBeDefined();
+        });
+
+        describe('.start([callback])', function() {
+
+          describe('Callbacks', function() {
+
+            it('should start pull replication', function(done) {
+              var replicator = getReplicator('pull');
+              expect(replicator).not.toBe(null);
+
+              // Start replication
+              replicator.start(function(error) {
+                expect(error).toBe(null);
+                done();
+              });
+            });
+
+            it('should start push replication', function(done) {
+              var replicator = getReplicator('push');
+              expect(replicator).not.toBe(null);
+
+              // Start replication
+              replicator.start(function(error) {
+                expect(error).toBe(null);
+                done();
+              });
+            });
+          }); // End-callbacks-tests
+
+          describe('Promises', function() {
+
+            it('should start pull replication', function(done) {
+              var replicator = getReplicator('pull');
+              expect(replicator).not.toBe(null);
+
+              replicator.start()
+                                .then(function() {
+                                  expect(true).toBe(true);
+                                })
+                                .catch(function(error) {
+                                  expect(error).toBe(null);
+                                })
+                                .fin(done);
+            });
+
+            it('should start push replication', function(done) {
+              var replicator = getReplicator('push');
+              expect(replicator).not.toBe(null);
+
+              // Start replication
+              replicator.start()
+                                .then(function() {
+                                  expect(true).toBe(true);
+                                })
+                                .catch(function(error) {
+                                  expect(error).toBe(null);
+                                })
+                                .fin(done);
+            });
+          }); // End-promises-tests
+
+        }); // End-start-tests
+
+        describe('.getState([callback])', function() {
+
+          describe('Callbacks', function() {
+
+            it('should poll pull replication status until completion', function(done) {
+              var replicator = getReplicator('pull');
+              expect(replicator).not.toBe(null);
+
+              var mtimer;
+
+              function poll(replicator) {
+                mtimer = setInterval(function() {
+                  replicator.getState(function(error,
+                      result) {
+                    expect(error).toBe(null);
+                    if (result === 'Complete') {
+                      stopPoll();
+                      done();
+                    }
+                  });
+                }, 500);
+              }
+
+              function stopPoll() {
+                clearInterval(mtimer);
+              }
+
+              // Start replication
+              replicator.start(function(error) {
+                expect(error).toBe(null);
+                poll(replicator); // Poll on the replication status
+              });
+            });
+
+            it('should poll push replication status until completion', function(done) {
+              var replicator = getReplicator('push');
+              expect(replicator).not.toBe(null);
+
+              var mtimer;
+
+              function poll(replicator) {
+                mtimer = setInterval(function() {
+                  replicator.getState(function(error,
+                      result) {
+                    expect(error).toBe(null);
+                    if (result === 'Complete') {
+                      stopPoll();
+                      done();
+                    }
+                  });
+                }, 500);
+              }
+
+              function stopPoll() {
+                clearInterval(mtimer);
+              }
+
+              // Start replication
+              replicator.start(function(error) {
+                expect(error).toBe(null);
+                poll(replicator); // Poll on the replication status
+              });
+            });
+
+            it('should poll two replication\'s status until completion', function(done) {
+              var pullReplicator = getReplicator('pull');
+              expect(pullReplicator).not.toBe(null);
+              var pushReplicator = getReplicator('push');
+              expect(pushReplicator).not.toBe(null);
+
+              var mtimer1, mtimer2;
+              var ncompletions = 0;
+
+              function poll(rep) {
+                return setInterval(repStatus, 2000, rep);
+              }
+
+              var repStatus = function(rep) {
+                rep.getState(function(error,
+                    result) {
+                  if (result ===
+                      'Complete') {
+                    ncompletions++;
+                  }
+                  if (ncompletions > 1) {
+                    stopPoll();
+                    done();
+                  }
+                });
+              };
+
+              function stopPoll() {
+                clearInterval(mtimer1);
+                clearInterval(mtimer2);
+              }
+
+              // Start replications
+              pullReplicator.start(function(error) {
+                expect(error).toBe(null);
+                // Start polling on replication status
+                mtimer1 = poll(pullReplicator);
+              });
+              pushReplicator.start(function(error) {
+                expect(error).toBe(null);
+                mtimer2 = poll(pushReplicator);
+              });
+            });
+          }); // End-callbacks-tests
+
+          describe('Promises', function() {
+
+            it('should poll pull replication status until completion', function(done) {
+              var replicator = getReplicator('pull');
+              expect(replicator).not.toBe(null);
+
+              var mtimer;
+
+              function poll(replicator) {
+                mtimer = setInterval(function() {
+                  replicator.getState()
+                                        .then(function(result) {
+                                          expect(result).not.toBe(null);
+                                          if (result === 'Complete') {
+                                            stopPoll();
+                                            done();
+                                          }
+                                        })
+                                        .catch(function(error) {
+                                          expect(error).toBe(null);
+                                        });
+                }, 500);
+              }
+
+              function stopPoll() {
+                clearInterval(mtimer);
+              }
+
+              // Start replication
+              replicator.start()
+                                .then(function() {
+                                  poll(replicator); // Poll on the replication status
+                                })
+                                .catch(function(error) {
+                                  expect(error).toBe(null);
+                                });
+            });
+
+            it('should poll push replication status until completion', function(done) {
+              var replicator = getReplicator('push');
+              expect(replicator).not.toBe(null);
+
+              var mtimer;
+
+              function poll(replicator) {
+                mtimer = setInterval(function() {
+                  replicator.getState()
+                                        .then(function(result) {
+                                          expect(result).not.toBe(null);
+                                          if (result === 'Complete') {
+                                            stopPoll();
+                                            done();
+                                          }
+                                        })
+                                        .catch(function(error) {
+                                          expect(error).toBe(null);
+                                        });
+                }, 500);
+              }
+
+              function stopPoll() {
+                clearInterval(mtimer);
+              }
+
+              replicator.start()
+                                .then(function() {
+                                  poll(replicator); // Poll on the replication status
+                                })
+                                .catch(function(error) {
+                                  expect(error).toBe(null);
+                                });
+            });
+
+            it('should poll two replication\'s status until completion', function(done) {
+              var pullReplicator = getReplicator('pull');
+              expect(pullReplicator).not.toBe(null);
+              var pushReplicator = getReplicator('push');
+              expect(pushReplicator).not.toBe(null);
+
+              var mtimer1, mtimer2;
+              var ncompletions = 0;
+
+              function poll(rep) {
+                return setInterval(repStatus, 2000, rep);
+              }
+
+              var repStatus = function(rep) {
+                rep.getState()
+                                    .then(function(result) {
+                                      if (result === 'Complete') {
+                                        ncompletions++;
+                                      }
+                                      if (ncompletions > 1) {
+                                        stopPoll();
+                                        done();
+                                      }
+                                    })
+                                    .catch(function(error) {
+                                      expect(error).not.toBe(null);
+                                    });
+              };
+
+              function stopPoll() {
+                clearInterval(mtimer1);
+                clearInterval(mtimer2);
+              }
+
+              // Start replicators
+              Q.all([pullReplicator.start(), pushReplicator.start()])
+                                .then(function() {
+                                  // Start polling on replication status
+                                  mtimer1 = poll(pullReplicator);
+                                  mtimer2 = poll(pushReplicator);
+                                })
+                                .catch(function(error) {
+                                  expect(error).toBe(null);
+                                });
+            });
+          }); // End-promises-tests
+
+        }); // End-getState-tests
+
+        describe('.stop([callback])', function() {
+
+          describe('Callbacks', function() {
+
+            it('should stop pull replication', function(done) {
+              var replicator = getReplicator('pull');
+              expect(replicator).not.toBe(null);
+
+              // Start replication
+              replicator.start(function(error) {
+                expect(error).toBe(null);
+                replicator.stop(function(error) {
+                  expect(error).toBe(null);
+                  done();
+                });
+              });
+            });
+
+            it('should stop push replication', function(done) {
+              var replicator = getReplicator('push');
+              expect(replicator).not.toBe(null);
+
+              // Start replication
+              replicator.start(function(error) {
+                expect(error).toBe(null);
+                replicator.stop(function(error) {
+                  expect(error).toBe(null);
+                  done();
+                });
+              });
+            });
+          }); // End-callbacks-tests
+
+          describe('Promises', function() {
+
+            it('should stop pull replication', function(done) {
+              var replicator = getReplicator('pull');
+              expect(replicator).not.toBe(null);
+
+              // Start replication
+              replicator.start()
+                                .then(function() {
+                                  return replicator.stop();
+                                })
+                                .catch(function(error) {
+                                  expect(error).toBe(null);
+                                })
+                                .fin(done);
+            });
+
+            it('should stop push replication', function(done) {
+              var replicator = getReplicator('pull');
+              expect(replicator).not.toBe(null);
+
+              // Start replication
+              replicator.start()
+                                .then(function() {
+                                  return replicator.stop();
+                                })
+                                .catch(function(error) {
+                                  expect(error).toBe(null);
+                                })
+                                .fin(done);
+            });
+          }); // End-promises-tests
+        }); // End-stop-tests
+
+        describe('.on(event, handler)', function() {
+          it('should register and fire a "complete" event', function(done) {
+            var replicator = getReplicator('pull');
+            expect(replicator).not.toBe(null);
+
+            replicator.on('complete', function(numDocs) {
+              expect(numDocs).not.toBe(null);
+              done();
+            });
+
+            replicator.start()
+                            .catch(function(error) {
+                              expect(error).toBe(null);
+                            });
+          });
+
+          it('should register and fire an "error" event', function(done) {
+            var datastore = getDatastore(storeDescription);
+            expect(datastore).not.toBe(null);
+
+            new ReplicatorBuilder().pull().to(datastore).from(uri + 'foo').build()
+                            .then(function(replicator) {
+                              expect(replicator).not.toBe(null);
+                              replicator.on('error', function(message) {
+                                expect(message).not.toBe(null);
+                                done();
+                              });
+
+                              return replicator.start();
+                            })
+                            .catch(function(error) {
+                              expect(error).toBe(null);
+                            });
+          });
+        });
+
+        describe('.destroy([callback])', function() {
+          describe('Callbacks', function() {
+            it('should destroy a replicator', function(done) {
+              try {
+                var replicator = getReplicator('pull');
+                expect(replicator).not.toBe(null);
+                expect(replicator.destroyed).not.toBeDefined();
+
+                replicator.destroy(function(error) {
+                  try {
+                    expect(error).toBe(null);
+                    expect(replicator.destroyed).toBe(true);
+                    done();
+                  } catch (e) {
+                    expect(e).toBe(null);
+                    done();
+                  }
+                });
+              } catch (e) {
+                expect(e).toBe(null);
+                done();
+              }
+            });
+          });
+
+          describe('Promises', function() {
+            it('should destroy a replicator', function(done) {
+              try {
+                var replicator = getReplicator('pull');
+                expect(replicator).not.toBe(null);
+                expect(replicator.destroyed).not.toBeDefined();
+
+                replicator.destroy()
+                                    .then(function() {
+                                      expect(replicator.destroyed).toBe(true);
+                                    })
+                                    .catch(function(error) {
+                                      expect(error).toBe(null);
+                                    })
+                                    .fin(done);
+              } catch (e) {
+                expect(e).toBe(null);
+                done();
+              }
+            });
+          });
+        });
+
+        describe('pull replication', function() {
+          it('should pull documents from animaldb', function(done) {
+            var replicator = getReplicator('pull');
+            expect(replicator).not.toBe(null);
+
+            replicator.on('complete', function(numDocs) {
+              expect(numDocs).not.toBe(null);
+
+              replicator.datastore.getDocument('aardvark')
+                                .then(function(documentRevision) {
+                                  expect(documentRevision).not.toBe(null);
+                                  expect(documentRevision._id).not.toBe(null);
+                                  expect(documentRevision._id).toBe('aardvark');
+                                  done();
+                                });
+            });
+
+            replicator.start()
+                            .catch(function(error) {
+                              expect(error).toBe(null);
+                            });
+          });
+        });
+
+        describe('push replication', function() {
+          it('should push documents to testdb', function(done) {
+            try {
+              var pushReplicator = getReplicator('push');
+              expect(pushReplicator).not.toBe(null);
+
+              var pullReplicator = getReplicator('pull');
+              expect(pullReplicator).not.toBe(null);
+
+              pullReplicator.on('complete', function(numDocs) {
+                expect(numDocs).not.toBe(null);
+              });
+
+              pullReplicator.on('error', function(message) {
+                expect(message).toBe(null);
+                done();
+              });
+
+              pushReplicator.on('complete', function(numDocs) {
+                expect(numDocs).not.toBe(null);
+                expect(numDocs).toBe(1);
+                done();
+              });
+
+              pushReplicator.on('error', function(message) {
+                expect(message).toBe(null);
+                done();
+              });
+
+              pullReplicator.on('complete',function(numDocs) {
+                pushReplicator.datastore.createDocumentFromRevision({
+                  foo: 'bar',
+                })
+                                    .then(function(savedRevision) {
+                                      expect(savedRevision).not.toBe(null);
+
+                                      return pushReplicator.start();
+                                    })
+                                    .catch(function(error) {
+                                      expect(error).toBe(null);
+                                      done();
+                                    });
+              });
+
+              pullReplicator.start()
+                                .catch(function(e) {
+                                  expect(e).toBe(null);
+                                });
+            } catch (e) {
+              console.log(e);
+              done();
+            }
+          });
+        });
+
+        describe('interceptors', function() {
+          it('should add a request header', function(done) {
+            var datastore = getDatastore(storeDescription);
+
+            new ReplicatorBuilder()
+                .pull()
+                .from(uri)
+                .to(datastore)
+                            .addRequestInterceptors(function(context) {
+                              expect(context).not.toBe(null);
+                              expect(context.request).toBeDefined();
+                              expect(context.request).not.toBe(null);
+                              expect(context.request.headers).toBeDefined();
+                              expect(context.request.headers).not.toBe(null);
+                              expect(context.request.url).toBeDefined();
+                              expect(context.request.url).not.toBe(null);
+
+                              expect(context.response).toBeDefined();
+                              expect(context.response).toBe(null);
+
+                              expect(context.replayRequest).toBeDefined();
+                              expect(context.replayRequest).not.toBe(null);
+
+                              context.request.headers['x-my-foo-header'] = 'bar';
+                              context.done();
+                            })
+                            .addResponseInterceptors(function(context) {
+                              expect(context).not.toBe(null);
+                              expect(context.request).toBeDefined();
+                              expect(context.request).not.toBe(null);
+                              expect(context.request.headers).toBeDefined();
+                              expect(context.request.headers).not.toBe(null);
+                              expect(context.request.headers['x-my-foo-header']).toBeDefined();
+                              expect(context.request.headers['x-my-foo-header']).toBe('bar');
+                              expect(context.request.url).toBeDefined();
+                              expect(context.request.url).not.toBe(null);
+
+                              expect(context.response).toBeDefined();
+                              expect(context.response).not.toBe(null);
+                              expect(context.response.statusCode).toBeDefined();
+                              expect(context.response.statusCode).not.toBe(null);
+                              expect(context.response.headers).toBeDefined();
+                              expect(context.response.headers).not.toBe(null);
+
+                              expect(context.replayRequest).toBeDefined();
+                              expect(context.replayRequest).not.toBe(null);
+
+                              context.done();
+
+                            }).build()
+                                .then(function(replicator) {
+                                  expect(replicator).not.toBe(null);
+
+                                  replicator.on('complete', function(numDocs) {
+                                    expect(numDocs).not.toBe(null);
+
+                                    replicator.datastore.getDocument('aardvark')
+                                            .then(function(documentRevision) {
+                                              expect(documentRevision).not.toBe(null);
+                                              expect(documentRevision._id).not.toBe(null);
+                                              expect(documentRevision._id).toBe('aardvark');
+                                              done();
+                                            });
+                                  });
+
+                                  return replicator.start();
+                                })
+                                .catch(function(error) {
+                                  expect(error).toBe(null);
+                                  done();
+                                });
+          });
+
+          it('should timeout', function(done) {
+            var datastore = getDatastore(storeDescription);
+
+            new ReplicatorBuilder()
+                .pull()
+                .from(uri)
+                .to(datastore)
+                            .addRequestInterceptors(function(context) {
+                              expect(context).not.toBe(null);
+                              expect(context.request).toBeDefined();
+                              expect(context.request).not.toBe(null);
+                              expect(context.request.headers).toBeDefined();
+                              expect(context.request.headers).not.toBe(null);
+
+                              context.request.headers['x-my-foo-header'] = 'bar';
+                              // NOT calling context.done() to force a timeout
+                            })
+                            .addResponseInterceptors(function(context) {
+                              expect(context).not.toBe(null);
+                              expect(context.request).toBeDefined();
+                              expect(context.request).not.toBe(null);
+                              expect(context.request.headers).toBeDefined();
+                              expect(context.request.headers).not.toBe(null);
+                              expect(context.request.headers['x-my-foo-header']).not.toBeDefined();
+
+                              context.done();
+
+                            }).build()
+                                .then(function(replicator) {
+                                  expect(replicator).not.toBe(null);
+
+                                  // Shortening the timeout duration
+                                  replicator.interceptors.timeout = 5000;
+
+                                  replicator.on('complete', function(numDocs) {
+                                    expect(numDocs).not.toBe(null);
+
+                                    replicator.datastore.getDocument('aardvark')
+                                            .then(function(documentRevision) {
+                                              expect(documentRevision).not.toBe(null);
+                                              expect(documentRevision._id).not.toBe(null);
+                                              expect(documentRevision._id).toBe('aardvark');
+                                              done();
+                                            });
+                                  });
+
+                                  return replicator.start();
+                                })
+                                .catch(function(error) {
+                                  expect(error).toBe(null);
+                              }).fin(done);
+          });
+
+          it('should execute two interceptors', function(done) {
+            var datastore = getDatastore(storeDescription);
+
+            var reqInterceptor1 = function(context) {
+              expect(context).not.toBe(null);
+              expect(context.request).toBeDefined();
+              expect(context.request).not.toBe(null);
+              expect(context.request.headers).toBeDefined();
+              expect(context.request.headers).not.toBe(null);
+
+              context.request.headers['x-my-foo-header'] = 'bar';
+              context.done();
+            };
+
+            var reqInterceptor2 = function(context) {
+              expect(context).not.toBe(null);
+              expect(context.request).toBeDefined();
+              expect(context.request).not.toBe(null);
+              expect(context.request.headers).toBeDefined();
+              expect(context.request.headers).not.toBe(null);
+
+              context.request.headers['x-my-bar-header'] = 'foo';
+              context.done();
+            };
+
+            var resInterceptor1 = function(context) {
+              expect(context).not.toBe(null);
+              expect(context.request).toBeDefined();
+              expect(context.request).not.toBe(null);
+              expect(context.request.headers).toBeDefined();
+              expect(context.request.headers).not.toBe(null);
+              expect(context.request.headers['x-my-foo-header']).toBeDefined();
+              expect(context.request.headers['x-my-foo-header']).toBe('bar');
+
+              context.done();
+            };
+
+            var resInterceptor2 = function(context) {
+              expect(context).not.toBe(null);
+              expect(context.request).toBeDefined();
+              expect(context.request).not.toBe(null);
+              expect(context.request.headers).toBeDefined();
+              expect(context.request.headers).not.toBe(null);
+              expect(context.request.headers['x-my-bar-header']).toBeDefined();
+              expect(context.request.headers['x-my-bar-header']).toBe('foo');
+
+              context.done();
+            };
+
+            new ReplicatorBuilder()
+                .pull()
+                .from(uri)
+                .to(datastore)
+                .addRequestInterceptors(reqInterceptor1, reqInterceptor2)
+                .addResponseInterceptors(resInterceptor1, resInterceptor2).build()
+                                .then(function(replicator) {
+                                  expect(replicator).not.toBe(null);
+
+                                  // Shortening the timeout duration
+                                  replicator.interceptors.timeout = 5000;
+
+                                  replicator.on('complete', function(numDocs) {
+                                    expect(numDocs).not.toBe(null);
+
+                                    replicator.datastore.getDocument('aardvark')
+                                            .then(function(documentRevision) {
+                                              expect(documentRevision).not.toBe(null);
+                                              expect(documentRevision._id).not.toBe(null);
+                                              expect(documentRevision._id).toBe('aardvark');
+                                              done();
+                                            });
+                                  });
+
+                                  return replicator.start();
+                                })
+                                .catch(function(error) {
+                                  expect(error).toBe(null);
+                                  done();
+                                });
+          });
+
+          it('should set the replay flag', function(done) {
+            var datastore = getDatastore(storeDescription);
+
+            var numTries = 0;
+            var url = null;
+            new ReplicatorBuilder()
+                .pull()
+                .from(uri + 'doesnotexist')
+                .to(datastore)
+                            .addRequestInterceptors(function(context) {
+                              expect(context).not.toBe(null);
+                              expect(context.request).toBeDefined();
+                              expect(context.request).not.toBe(null);
+                              expect(context.request.url).toBeDefined();
+                              expect(context.request.url).not.toBe(null);
+
+                              // Capture the first request url
+                              if (!url) {
+                                url = context.request.url;
+                              }
+
+                              context.done();
+                            })
+                            .addResponseInterceptors(function(context) {
+
+                              expect(context).not.toBe(null);
+                              expect(context.request).toBeDefined();
+                              expect(context.request).not.toBe(null);
+                              expect(context.request.url).toBeDefined();
+                              expect(context.request.url).not.toBe(null);
+                              expect(context.response.statusCode).toBeDefined();
+                              expect(context.response.statusCode).not.toBe(null);
+                              expect(context.replayRequest).toBeDefined();
+                              expect(context.replayRequest).not.toBe(null);
+
+                              // Tick up the number of times the first request has been sent
+                              if (context.request.url === url) {
+                                numTries++;
+
+                                // If the url has only been requested once try again
+                                if (context.response.statusCode === 404 && numTries < 2) {
+                                  context.replayRequest = true;
+                                }
+                              }
+
+                              context.done();
+
+                            }).build()
+                                .then(function(replicator) {
+                                  expect(replicator).not.toBe(null);
+
+                                  replicator.on('error', function(error) {
+                                    expect(error).not.toBe(null);
+                                    expect(numTries).toBe(2);
+                                    done();
+                                  });
+
+                                  return replicator.start();
+                                })
+                                .catch(function(error) {
+                                  expect(error).toBe(null);
+                                  done();
+                                });
+          });
+        });
+      }); // End-Replicator-tests
+    }
+
+    testReplication('local');
+  });
 };

--- a/tests/Tests.js
+++ b/tests/Tests.js
@@ -6,7 +6,7 @@ var replication = require('cloudant-sync-tests.ReplicationTests');
 
 exports.defineAutoTests = function() {
   // Time out in milliseconds
-  jasmine.DEFAULT_TIMEOUT_INTERVAL = 480000;
+  jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
   dbCreate.defineAutoTests();
   attachments.defineAutoTests();
   crud.defineAutoTests();


### PR DESCRIPTION
## What

Make it possible to display where to place the datastore on disk, instead of it being fixed to the hybrid datastore directory.
## How

Change the datastore manager object to a function which creates the datastore manager object. This allows using promises to wait for the native layer to create the datastore manager. The function takes an argument `options` with has the single parameter `path` which is optional and defaults to `CloudantSync` in the applications data directory as determined by the `cordova-plugin-file` plugin.
## Reviewers

reviewer @brynh 
reviewer @tomblench 
## Issues

Fixes #6 
## Notes

Tests are expected to fail due to an issue with `OutOfMemoryException` being thrown, this will be fixed by remove ability to encrypt datastores until a fix can be found; issue #38 handles removing encryption support.
