### PR TITLE
Add API to close Datastores.

### DIFF
--- a/src/android/CloudantSyncPlugin.java
+++ b/src/android/CloudantSyncPlugin.java
@@ -68,6 +68,7 @@ public class CloudantSyncPlugin extends CordovaPlugin {
 
     private static final String ACTION_CREATE_DATASTORE_MANAGER = "createDatastoreManager";
     private static final String ACTION_OPEN_DATASTORE = "openDatastore";
+    private static final String ACTION_CLOSE_DATASTORE = "closeDatastore";
     private static final String ACTION_DELETE_DATASTORE = "deleteDatastore";
     private static final String ACTION_SAVE = "save";
     private static final String ACTION_GET_DOCUMENT = "getDocument";
@@ -126,6 +127,8 @@ public class CloudantSyncPlugin extends CordovaPlugin {
 
             openDatastore(datastoreManagerId, datastoreName, callbackContext);
 
+        } else if (ACTION_CLOSE_DATASTORE.equals(action)) {
+            closeDatastore(args, callbackContext);
         } else if (ACTION_DELETE_DATASTORE.equals(action)) {
             final int datastoreManagerId = args.getInt(0);
             final String name = JSONObject.NULL.equals(args.get(1)) ? null : args.getString(1);
@@ -275,6 +278,26 @@ public class CloudantSyncPlugin extends CordovaPlugin {
                     callbackContext.success(r);
                 } catch (Exception e) {
                     callbackContext.error(e.getMessage());
+                }
+            }
+        });
+    }
+
+    private void closeDatastore(final JSONArray args, final CallbackContext callbackContext) {
+        cordova.getThreadPool().execute(new Runnable(){
+            @Override
+            public void run() {
+                try{
+                    Datastore ds = datastores.remove(args.getString(0));
+                    if(ds == null){
+                        callbackContext.error("Datastore is not open");
+                        return;
+                    }
+
+                    ds.close();
+                    callbackContext.success();
+                } catch (Exception e){
+                    callbackContext.error("Datastore could not be closed");
                 }
             }
         });

--- a/src/ios/CDTSyncPlugin.m
+++ b/src/ios/CDTSyncPlugin.m
@@ -134,6 +134,14 @@
     }];
 }
 
+- (void)closeDatastore:(CDVInvokedUrlCommand *) command
+{
+    // CDTDatastore doesn't have a close method, so just return success
+    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+
+}
+
 -(void)deleteDatastore:(CDVInvokedUrlCommand *)command
 {
     [self.commandDelegate runInBackground:^{

--- a/tests/DatastoreTests.js
+++ b/tests/DatastoreTests.js
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2016 IBM Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ */
+
+var DatastoreManager = require('cloudant-sync.DatastoreManager').DatastoreManager;
+
+var dbName = 'DatastoreTests';
+
+exports.defineAutoTests = function() {
+
+  var datastore;
+  var manager;
+
+  beforeAll(function(done) {
+    DatastoreManager({})
+        .then(function(localManager) {
+          manager = localManager;
+        }).fin(done);
+  });
+
+
+  beforeEach(function(done) {
+    manager.openDatastore(dbName)
+     .then(function(ds) {
+        datastore = ds;
+      }).fin(done);
+  });
+
+  afterEach(function(done) {
+    manager.deleteDatastore(dbName)
+    .fin(done);
+  });
+
+
+  describe('it is possible to close the datastore', function() {
+    describe('using callbacks', function() {
+
+      it('successfully closes a datastore', function(done) {
+
+        function callback(error) {
+          expect(error).toBe(null);
+          done();
+        }
+
+        datastore.close(callback);
+      });
+
+      it('fails to close an already closed datastore', function(done) {
+        datastore.close(function(error) {
+          expect(error).toBe(null);
+          datastore.close(function(error) {
+            expect(error).not.toBe(null);
+            done();
+          });
+        });
+
+      });
+
+    });
+
+    describe('using promises', function() {
+      it('successfully closes a datastore', function(done) {
+
+        datastore.close()
+        .then(function() {
+          // This prevents jasmine trying to be clever and say we didn't
+          // have any expectations
+          expect(true).toBe(true);
+        })
+        .catch(function(error) {
+          fail('Closing datastroe should not have failed');
+        }).fin(done);
+      });
+
+      it('fails to close an already closed datastore', function(done) {
+
+        datastore.close()
+          .then(function() {
+            return datastore.close();
+          }).then(function() {
+            fail('closing datastore should have failed');
+          }).catch(function(error) {
+            expect(error).not.toBe(null);
+          }).fin(done);
+      });
+    });
+  });
+
+
+};

--- a/tests/Tests.js
+++ b/tests/Tests.js
@@ -3,6 +3,7 @@ var attachments = require('cloudant-sync-tests.AttachmentsTests');
 var crud = require('cloudant-sync-tests.CRUDTests');
 var indexAndQuery = require('cloudant-sync-tests.IndexAndQueryTests');
 var replication = require('cloudant-sync-tests.ReplicationTests');
+var datastoreTests = require('cloudant-sync-tests.DatastoreTests');
 
 exports.defineAutoTests = function() {
   // Time out in milliseconds
@@ -12,4 +13,5 @@ exports.defineAutoTests = function() {
   crud.defineAutoTests();
   indexAndQuery.defineAutoTests();
   replication.defineAutoTests();
+  datastoreTests.defineAutoTests();
 };

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -30,6 +30,7 @@
     <js-module name="CRUDTests" src="CRUDTests.js"/>
     <js-module name="IndexAndQueryTests" src="IndexAndQueryTests.js"/>
     <js-module name="ReplicationTests" src="ReplicationTests.js"/>
+    <js-module name="DatastoreTests" src="DatastoreTests.js"/>
     <js-module name="tests" src="Tests.js" />
 
     <platform name="android">

--- a/www/datastoremanager.js
+++ b/www/datastoremanager.js
@@ -226,6 +226,38 @@ function Datastore(name) {
 
 exports.Datastore = Datastore;
 
+
+/**
+ * @summary Closes the datastore and releases native resources.
+ *
+ * @description Closes the datastore and releases native resources, once closed
+ * a datastore can not be reused.
+ *
+ * @param {Datastore~closeCallback} [callback] function to call after the
+ * datastore has been closed.
+ *
+ * @returns A [q style promise]{@link https://github.com/kriskowal/q}.
+ */
+Datastore.prototype.close = function(callback) {
+  var defer = Q.defer();
+
+  function success() {
+    defer.resolve();
+  }
+
+  function failed(err) {
+    defer.reject(err);
+  }
+
+
+  exec(success , failed, 'CloudantSync', 'closeDatastore', [this.name]);
+
+  defer.promise.nodeify(callback);
+  return defer.promise;
+
+
+};
+
 /**
  * @summary Adds a new document with body and attachments from revision.
  * @description If '_id' in the revision is null or undefined, the document's
@@ -649,3 +681,8 @@ function save(dbName, documentRevision, callback) {
  * @param {?Error} error
  * @param {Array} results - The query results.
  */
+
+ /**
+  * @callback Datastore~closeCallback
+  * @param {?Error} error
+  */


### PR DESCRIPTION
## What

Added new API to close datastores to release native resources.
## How

Added `close` method to the `datastore` object. It returns a promise and optionally take a callback.
## Reviewers

reviewer @brynh 
reviewer @emlaver
## Issues

Fixes #41
