### PR TITLE
Refactor 'save' operation

### DIFF
--- a/src/ios/CDTSyncPlugin.h
+++ b/src/ios/CDTSyncPlugin.h
@@ -22,7 +22,7 @@
 
 -(void)deleteDatastore:(CDVInvokedUrlCommand*)command;
 
--(void)save:(CDVInvokedUrlCommand*)command;
+-(void)createOrUpdateDocumentFromRevision:(CDVInvokedUrlCommand*)command;
 
 -(void)getDocument:(CDVInvokedUrlCommand*)command;
 

--- a/src/ios/CDTSyncPlugin.m
+++ b/src/ios/CDTSyncPlugin.m
@@ -166,12 +166,13 @@
 }
 
 #pragma mark - CRUD operations
-- (void)save:(CDVInvokedUrlCommand*)command
+- (void)createOrUpdateDocumentFromRevision:(CDVInvokedUrlCommand*)command
 {
     [self.commandDelegate runInBackground:^{
         CDVPluginResult* pluginResult = nil;
         NSString *name = [command argumentAtIndex:0];
         NSDictionary *docRevisionJSON = [command argumentAtIndex:1];
+        BOOL isCreate = [[command argumentAtIndex:2] boolValue];
 
         // Lookup store in cache
         CDTDatastore *cachedStore = self.datastoreMap[name];
@@ -181,8 +182,6 @@
             if(!jsonConversionError){
                 // perform save
                 CDTDocumentRevision *savedRevision = nil;
-
-                BOOL isCreate = !revision.revId;
 
                 NSError *error;
                 if(isCreate){
@@ -298,7 +297,7 @@
                 } else {
                     // Error occurred, create response
                     NSLog(@"Document delete error:%@",[error.userInfo objectForKey:NSLocalizedDescriptionKey]);
-                    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[NSString stringWithFormat: NSLocalizedString(@"Failed to save document revision.  Error: %@", nil), error]];
+                    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[NSString stringWithFormat: NSLocalizedString(@"Failed to delete document revision.  Error: %@", nil), error]];
                 }
                 [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
             }else{


### PR DESCRIPTION
Refactor the `save` method in the JavaScript and the corresponding `save` methods in native iOS and Android code to make future maintenance easier.

Issue #14 was raised to stop `createDocumentFromRevision` and `updateDocumentFromRevision` from sharing a single code path to make it easier to maintain in the future.  In evaluating this issue, I don't see a particular issue with the shared code path and removing the shared code is likely to cause duplication of code, which is itself a maintenance issue.  However, this PR does make a few modifications, that will hopefully provide some benefit for future maintenance:
- Renaming 'save' to 'createOrUpdateDocumentFromRevision' - this provides more consistent naming when tracing the code through the JavaScript and native code. The existing `save` method was only called from methods named `createDocumentFromRevision` and `updateDocumentFromRevision` and after calling native `save` methods then called native methods named `createDocumentFromRevision` and `updateDocumentFromRevision`
- Removal of some duplicate checks.
- Validating arguments more consistently.
- Rather than attempting to re-derive whether it's a create or update operation from the contents of the `documentRevision`, we now pass an indicator of whether it's a create or update through the shared code path as we know whether it's a create or update at the point of calling `createOrUpdateDocumentFromRevision'.

Fixes #14 _(ish - it doesn't do exactly what #14 asks for, but does make some improvements for maintainability)_
