### PR TITLE
57 travis ios

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,56 @@
-language: android
+language: node_js
+
+matrix:
+    include:
+        - os: linux
+          language: android
+          android:
+            components:
+              # Uncomment the lines below if you want to
+              # use the latest revision of Android SDK Tools
+              - platform-tools
+              - tools
+
+              # The BuildTools version used by your project
+              - build-tools-19.1.0
+
+              # The SDK version used to compile your project
+              - android-23
+
+              # Additional components
+              - extra-google-m2repository
+              - extra-android-m2repository
+
+              # Specify at least one system image,
+              # if you need to run emulator(s) during your tests
+              - sys-img-x86-android-21
+              - sys-img-armeabi-v7a-android-21
+          script:
+            # Launch Android emulator
+            #- echo no | android create avd --force -n test -t android-21 --abi x86
+            - echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a
+            - emulator -avd test -no-audio -no-window &
+            - android-wait-for-emulator
+            - npm run test-platform -- 'android'
+        - os: osx
+          language: objective-c
+          osx_image: xcode8
+          before_install:
+            - brew install couchdb
+            - brew services start couchdb
+          script:
+            - travis_wait 25 npm run test-platform -- 'ios'
 
 services:
     - couchdb
-
-android:
-  components:
-    # Uncomment the lines below if you want to
-    # use the latest revision of Android SDK Tools
-    - platform-tools
-    - tools
-
-    # The BuildTools version used by your project
-    - build-tools-19.1.0
-
-    # The SDK version used to compile your project
-    - android-23
-
-    # Additional components
-    - extra-google-m2repository
-    - extra-android-m2repository
-
-    # Specify at least one system image,
-    # if you need to run emulator(s) during your tests
-    - sys-img-x86-android-21
-    - sys-img-armeabi-v7a-android-21
 
 before_script:
     # Update npm
     - npm update -g npm
     # Run setup to replicate animaldb
     - ./setup.rb
-    # Launch Android emulator
-    #- echo no | android create avd --force -n test -t android-21 --abi x86
-    - echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a
-    - emulator -avd test -no-audio -no-window &
-    - android-wait-for-emulator
-
-script:
     - npm install
-    - npm run test-platform -- 'android'
+
+after_script:
     # for now only check javascript production source files follow guidelines.
     - npm run lint


### PR DESCRIPTION
_What_

Enable iOS tests for Travis

Note: reviewers can just look at the `.travis.yml` changes, the framework changes will be part of another PR, but were necessary to validate the iOS tests were running correctly).

_How_
- Added matrix to `.travis.yml` including linux and iOS
- Moved elements of platform specific script into matrix overrides

_Testing_

Travis now runs the npm tests for each platform and they pass.

_Issues_

Fixes #57 
