### PR TITLE
Use known versions (with patch level changes) for dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
     "q": "~1.4.1"
   },
   "devDependencies": {
-    "cordova": "latest",
-    "cordova-paramedic": "latest",
-    "jscs": "latest"
+    "cordova": "~6.4.0",
+    "cordova-paramedic": "~0.5.0",
+    "jscs": "~3.0.7"
   },
   "scripts": {
     "cpm": "cordova-paramedic --plugin . --verbose --timeout 1200000 ",


### PR DESCRIPTION
So that the cordova plugin should continue to work "out of the box", don't use `latest` versions of dev dependencies. Instead use known versions (with patch-level changes allowed).

Fixes #69 