### PR TITLE
Use the correct PRODUCT_NAME in LD_RUNPATH_SEARCH_PATHS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 - [FIXED] Renamed attachment property `content_type` from `contentType` to match
   the documentation and CouchDB format.
+- [FIXED] Issue causing crash on startup of iOS apps due to required frameworks not being added to LD_RUNPATH_SEARCH_PATHS.
+- [IMPROVED] Documentation describing process to configure for running on iOS devices.
 
 # 0.3.0 (2016-12-13)
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,24 @@ Add iOS as a platform
 $ cordova platform add ios
 ```
 
+### Running on an iOS device
+
+To run the cordova app on an iOS device, the following steps are necessary:
+1. Open the iOS project in Xcode (the app is in the `platforms/ios` subdirectory).
+1. General > Signing > Team:<br/>
+   Set the team so the app can be signed.
+1. General > Linked Frameworks and Libraries:<br/>
+   Remove `CocoaLumberjack.framework`, `CDTDatastore.framework`, `FMDB.framework`.
+1. General > Embedded Binaries:<br/>
+   Add `CocoaLumberjack.framework`, `CDTDatastore.framework`, `FMDB.framework`.
+1. Build Phases > Embed Frameworks:<br/>
+   Change “Destination” to `Shared Frameworks`.
+1. Execute the command `cordova run ios`.
+1. If necessary, accept the developer profile on the device by going to
+   Settings > General > Profiles & Device Management > Developer App > <dev_profile>
+   and clicking “Trust <dev_profile>” and re-run the app either on the device or
+   by rerunning `cordova run ios`.
+
 ## Overview of the library
 
 Once the plugin has been added to a project, the basics are:

--- a/hooks/embedFramework.sh
+++ b/hooks/embedFramework.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-sed -i .orig 's/\(LD_RUNPATH_SEARCH_PATHS = "[^"]*\)\(".*$\)/\1 \${PROJECT_DIR}\/HelloCordova\/Plugins\/cloudant-sync\2/' platforms/ios/HelloCordova.xcodeproj/project.pbxproj
+sed -i .orig 's/\(LD_RUNPATH_SEARCH_PATHS = "[^"]*\)\(".*$\)/\1 \${PROJECT_DIR}\/${PRODUCT_NAME}\/Plugins\/cloudant-sync @executable_path\/SharedFrameworks\2/' platforms/ios/*.xcodeproj/project.pbxproj


### PR DESCRIPTION
### What
Update the script run after a `cordova platform add ios` so it doesn't assume the iOS app is always called `HelloCordova`. 

Describe the manual process to configure xcode so that an app using the sync-cordova-plugin can be deployed to an iOS device.

### Testing
This has been manually tested using a number of product names and tested on an iOS device following the manual configuration process described.

Fixes #76 