### PR TITLE
Replaced contentType with content_type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
+# Unreleased
+
+- [FIXED] Renamed attachment property `content_type` from `contentType` to match
+  the documentation and CouchDB format.
+
 # 0.3.0 (2016-12-13)
 
 - Initial release.
-

--- a/src/android/CloudantSyncPlugin.java
+++ b/src/android/CloudantSyncPlugin.java
@@ -91,7 +91,7 @@ public class CloudantSyncPlugin extends CordovaPlugin {
     private static final String DOC_REV = "_rev";
     private static final String DOC_DELETED = "_deleted";
     private static final String DOC_ATTACHMENTS = "_attachments";
-    private static final String DOC_ATTACHMENTS_CONTENT_TYPE = "contentType";
+    private static final String DOC_ATTACHMENTS_CONTENT_TYPE = "content_type";
     private static final String DOC_ATTACHMENTS_DATA = "data";
 
     private static final String REPLICATOR_TOKEN = "token";

--- a/src/ios/CDTSyncPlugin.m
+++ b/src/ios/CDTSyncPlugin.m
@@ -28,7 +28,7 @@
 #define kCDTDocDeleted @"_deleted"
 
 #define kCDTDocAttachments @"_attachments"
-#define kCDTDocAttachmentContentType @"contentType"
+#define kCDTDocAttachmentContentType @"content_type"
 #define kCDTDocAttachmentData @"data"
 
 // Query

--- a/tests/AttachmentsTests.js
+++ b/tests/AttachmentsTests.js
@@ -76,7 +76,7 @@ exports.defineAutoTests = function() {
             ageAdjustment: 10,
             _attachments: {
               face: {
-                contentType: 'image/jpeg',
+                content_type: 'image/jpeg',
                 data: todd_image,
               },
             },
@@ -142,11 +142,11 @@ exports.defineAutoTests = function() {
               ageAdjustment: 12,
               _attachments: {
                 face: {
-                  contentType: 'image/jpeg',
+                  content_type: 'image/jpeg',
                   data: dillon_image,
                 },
                 idolFace: {
-                  contentType: 'image/jpeg',
+                  content_type: 'image/jpeg',
                   data: todd_image,
                 },
               },
@@ -191,11 +191,11 @@ exports.defineAutoTests = function() {
               ageAdjustment: 12,
               _attachments: {
                 face: {
-                  contentType: 'image/jpeg',
+                  content_type: 'image/jpeg',
                   data: dillon_image,
                 },
                 idolFace: {
-                  contentType: 'image/jpeg',
+                  content_type: 'image/jpeg',
                   data: todd_image,
                 },
               },
@@ -287,7 +287,7 @@ exports.defineAutoTests = function() {
               age: 30,
               _attachments: {
                 face: {
-                  contentType: 'image/jpeg',
+                  content_type: 'image/jpeg',
                   data: todd_image,
                 },
               },
@@ -328,7 +328,7 @@ exports.defineAutoTests = function() {
               }
             });
 
-            it('missing contentType', function(done) {
+            it('missing content_type', function(done) {
               var datastore = getDatastore(storeDescription);
               expect(datastore).not.toBe(null);
               var badAttachments = {
@@ -354,7 +354,7 @@ exports.defineAutoTests = function() {
               expect(datastore).not.toBe(null);
               var badAttachments = {
                 face: {
-                  contentType: 'image/jpeg',
+                  content_type: 'image/jpeg',
                 },
               };
 
@@ -381,7 +381,7 @@ exports.defineAutoTests = function() {
             ageAdjustment: 10,
             _attachments: {
               face: {
-                contentType: 'image/jpeg',
+                content_type: 'image/jpeg',
                 data: todd_image,
               },
             },
@@ -511,7 +511,7 @@ exports.defineAutoTests = function() {
               age: 30,
               _attachments: {
                 face: {
-                  contentType: 'image/jpeg',
+                  content_type: 'image/jpeg',
                   data: todd_image,
                 },
               },
@@ -565,7 +565,7 @@ exports.defineAutoTests = function() {
               }
             });
 
-            it('missing contentType', function(done) {
+            it('missing content_type', function(done) {
               var datastore = getDatastore(storeDescription);
               expect(datastore).not.toBe(null);
               var badAttachments = {
@@ -596,7 +596,7 @@ exports.defineAutoTests = function() {
               expect(datastore).not.toBe(null);
               var badAttachments = {
                 face: {
-                  contentType: 'image/jpeg',
+                  content_type: 'image/jpeg',
                 },
               };
 
@@ -733,11 +733,11 @@ exports.defineAutoTests = function() {
             age: i,
             _attachments: {
               face: {
-                contentType: 'image/jpeg',
+                content_type: 'image/jpeg',
                 data: dillon_image,
               },
               idolFace: {
-                contentType: 'image/jpeg',
+                content_type: 'image/jpeg',
                 data: todd_image,
               },
             },

--- a/tests/ConflictTests.js
+++ b/tests/ConflictTests.js
@@ -576,7 +576,7 @@ exports.defineAutoTests = function () {
                             {
                               myLocalAttachment:
                                       {
-                                        contentType: 'text-plain',
+                                        content_type: 'text-plain',
                                         data: btoa('Local attachment') // bota only supports ASCII, not Unicode.
                                       }
                             }
@@ -679,7 +679,7 @@ exports.defineAutoTests = function () {
                             {
                               myLocalAttachment:
                                       {
-                                        contentType: 'text-plain',
+                                        content_type: 'text-plain',
                                         data: btoa('Local attachment') // bota only supports ASCII, not Unicode.
                                       }
                             }
@@ -1064,7 +1064,7 @@ exports.defineAutoTests = function () {
                             {
                               myLocalAttachment:
                                       {
-                                        contentType: 'text-plain',
+                                        content_type: 'text-plain',
                                         data: btoa('Local attachment') // bota only supports ASCII, not Unicode.
                                       }
                             }
@@ -1178,7 +1178,7 @@ exports.defineAutoTests = function () {
                             {
                               myLocalAttachment:
                                       {
-                                        contentType: 'text-plain',
+                                        content_type: 'text-plain',
                                         data: btoa('Local attachment') // bota only supports ASCII, not Unicode.
                                       }
                             }

--- a/www/datastoremanager.js
+++ b/www/datastoremanager.js
@@ -717,7 +717,7 @@ function validateDocumentRevision(documentRevision) {
             attachmentName + ' had no data');
       }
 
-      if (_.isEmpty(attachment.contentType)) {
+      if (_.isEmpty(attachment.content_type)) {
         throw new Error(
             'documentRevision contained invalid attachment.  ' +
             attachmentName + ' had no content_type');


### PR DESCRIPTION
*What*

Renamed `contentType` attachment property to `content_type`

*How*

* Changed the value from `contentType` to `content_type` for the constants:
    * `CloudantSyncPlugin,DOC_ATTACHMENTS_CONTENT_TYPE`
    * `CDTSyncPlugin.kCDTDocAttachmentContentType`
* Updated property name for validation in `datastoremanager.js`

*Testing*

Renamed `contentType` to `content-type` for test cases using that property.
No new tests added.

*Issues*

Fixes #80 