### PR TITLE
Clarify deletion of frameworks from Linked Frameworks and Libraries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ To run the cordova app on an iOS device, the following steps are necessary:
    Remove `CocoaLumberjack.framework`, `CDTDatastore.framework`, `FMDB.framework`.
 1. General > Embedded Binaries:<br/>
    Add `CocoaLumberjack.framework`, `CDTDatastore.framework`, `FMDB.framework`.
+   _Note that this step adds these frameworks back to "Linked Frameworks and Libraries"
+   as well as adding them to "Embedded Binaries". The libraries should be left in both
+   sections. Their removal in the previous step is simply to prevent each framework appearing
+   twice in "Linked Frameworks and Libraries"._
 1. Build Phases > Embed Frameworks:<br/>
    Change “Destination” to `Shared Frameworks`.
 1. Execute the command `cordova run ios`.


### PR DESCRIPTION
In response to [this comment](https://github.com/cloudant/sync-cordova-plugin/issues/76#issuecomment-288631033), clarify that Frameworks should be left in `Linked Frameworks and Libraries` as per [my response](https://github.com/cloudant/sync-cordova-plugin/issues/76#issuecomment-288683018) to the comment.