### PR TITLE
Upgrade to sync-android version 2.0.0.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
   the documentation and CouchDB format.
 - [FIXED] Issue causing crash on startup of iOS apps due to required frameworks not being added to LD_RUNPATH_SEARCH_PATHS.
 - [IMPROVED] Documentation describing process to configure for running on iOS devices.
+- [UPGRADED] Cloudant sync-android dependency to version 2.0.0.
 
 # 0.3.0 (2016-12-13)
 

--- a/assets/sync-extras.gradle
+++ b/assets/sync-extras.gradle
@@ -14,7 +14,7 @@
  */
 
 dependencies {
-		compile group: 'com.cloudant', name: 'cloudant-sync-datastore-android-encryption', version:'1.1.5'
+		compile group: 'com.cloudant', name: 'cloudant-sync-datastore-android-encryption', version:'2.0.0'
 }
 
 android {

--- a/src/android/SyncPluginListener.java
+++ b/src/android/SyncPluginListener.java
@@ -1,7 +1,7 @@
 package com.cloudant.sync.cordova;
 
-import com.cloudant.sync.notifications.ReplicationCompleted;
-import com.cloudant.sync.notifications.ReplicationErrored;
+import com.cloudant.sync.event.notifications.ReplicationCompleted;
+import com.cloudant.sync.event.notifications.ReplicationErrored;
 import com.cloudant.sync.event.Subscribe;
 
 import org.apache.cordova.CallbackContext;
@@ -11,7 +11,7 @@ import org.json.JSONArray;
 /**
  * The SyncPluginListener Class proxies replication events to the javascript layer. Each new Replicator is registered with an instance of this class.
  */
-class SyncPluginListener {
+public class SyncPluginListener {
     public final CallbackContext context;
 
     SyncPluginListener(CallbackContext context) {
@@ -33,7 +33,7 @@ class SyncPluginListener {
     public void error(ReplicationErrored error) {
         JSONArray result = new JSONArray();
         result.put("error");
-        result.put(error.errorInfo.getException().toString());
+        result.put(error.errorInfo.toString());
 
         PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, result);
         pluginResult.setKeepCallback(true);


### PR DESCRIPTION
### What

Upgrade the sync-android dependency to version 2.0.0.

### How

Updated the dependency and migrated the code according to the [sync-android migration guide](https://github.com/cloudant/sync-android/blob/master/doc/migration.md).

Note that because common JavaScript code calls through to native Android and iOS code, there will be some additional cleanup that can be done across the interface if CDTDatastore is ever modified to have similar changes to those introduced in sync-android v2.0.0 (e.g. use of `DocumentStore` instead of `Datastore`). Because we have these two code bases, the names across the JS/Android interface have been left as they were (sometimes referring to `Datastore`), but where possible internally on the Android side everything has been changed to `DocumentStore`.

### Testing
No new tests added. All existing tests pass.

Fixes #83 
