### PR TITLE
90 json conversion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 matrix:
     include:
         - os: linux
+          dist: precise
           language: android
           sudo: required
           android:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [FIXED] Issue where nested JSON objects treated as strings not JSON.
+
 # 0.4.0 (2017-04-07)
 
 - [FIXED] Renamed attachment property `content_type` from `contentType` to match

--- a/tests/CRUDTests.js
+++ b/tests/CRUDTests.js
@@ -119,6 +119,8 @@ exports.defineAutoTests = function() {
             lastName: 'Kaplinger',
             numberOne: 1,
             numberFive: 5,
+            assignments: ['zero', 'one'],
+            cv: {education: 'Masters', skills: ['javascript', 'java']}
           };
 
           var objWithoutBody = {};
@@ -190,6 +192,45 @@ exports.defineAutoTests = function() {
                 expect(fetchedRevision._rev).toBeDefined();
                 expect(fetchedRevision.firstName)
                     .toBe(employee.firstName);
+                done();
+              }); //End-getDocument
+            }); //End-create
+          });
+
+          it('finds a document revision by docId (nested)', function(done) {
+            var datastore = getDatastore(datastoreDescription);
+            expect(datastore).not.toBe(null);
+
+            // Create
+            datastore.createDocumentFromRevision(employee, function(error, docRevision) {
+              expect(error).toBe(null);
+              expect(docRevision).not.toBe(null);
+              expect(docRevision._id).toBeDefined();
+              expect(docRevision._rev).toBeDefined();
+              expect(docRevision.firstName).toBe(employee.firstName);
+              expect(docRevision.assignments[0]).toBe(employee.assignments[0]);
+              expect(docRevision.assignments[1]).toBe(employee.assignments[1]);
+              expect(docRevision.cv.education).toBe(employee.cv.education);
+              expect(docRevision.cv.skills[0]).toBe(employee.cv.skills[0]);
+
+              // GetDocument
+              datastore.getDocument(docRevision._id, function(
+                  error, fetchedRevision) {
+                expect(error).toBe(null);
+                expect(fetchedRevision).not.toBe(
+                    null);
+                expect(fetchedRevision._id).toBeDefined();
+                expect(fetchedRevision._rev).toBeDefined();
+                expect(fetchedRevision.firstName)
+                    .toBe(employee.firstName);
+                expect(fetchedRevision.assignments[0])
+                    .toBe(employee.assignments[0]);
+                expect(fetchedRevision.assignments[1])
+                    .toBe(employee.assignments[1]);
+                expect(fetchedRevision.cv.education)
+                    .toBe(employee.cv.education);
+                expect(fetchedRevision.cv.skills[0])
+                    .toBe(employee.cv.skills[0]);
                 done();
               }); //End-getDocument
             }); //End-create


### PR DESCRIPTION
*What*

Fixed issue with nested JSON by using the built-ins.

*How*

Previously `buildJSON` was iterating the `Map<String, Object>` and adding entries by key and value into the `JSONObject`. This had the side effect of treating nested JSON as strings. The `JSONObject` has a `Map` constructor so it is preferable to use that to get full JSON conversion and then just add the special case fields to that object.
Additionally the reverse `getMapFromJSONObject` iterates the `JSONObject` adding the entries into a `Map`, we can remove the special case fields and then use the `DocumentBodyFactory.create(byte[])`  instead to ensure we use the built-in JSON to `DocumentBody` instead of possibly adding `JSONObject` or `JSONArray` into the `Map` values and them not being converted.

*Tests*

Added nested JSON to the test document structure.
Added a test to check the document with nested JSON structures
Note: changed Travis to `dist:precise` where things run correctly

*Issues*

Fixes #90 