### PR TITLE
91 travis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
             - echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a
             - emulator -avd test -no-audio -no-window &
             - android-wait-for-emulator
-            - npm run test-platform -- 'android'
+            - travis_wait 30 npm run test-platform -- 'android'
         - os: osx
           language: objective-c
           osx_image: xcode8
@@ -42,10 +42,7 @@ matrix:
             - brew install couchdb
             - brew services start couchdb
           script:
-            - travis_wait 25 npm run test-platform -- 'ios'
-
-services:
-    - couchdb
+            - travis_wait 30 npm run test-platform -- 'ios'
 
 before_script:
     # Update npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,6 @@ before_script:
     - ./setup.rb
     - nvm install 6
     - npm install
-
-after_script:
     # for now only check javascript production source files follow guidelines.
     - npm run lint
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,58 +1,72 @@
 language: node_js
 
+android:
+  components:
+    # Tools listed twice because doc says it's needed to get updates
+    # https://docs.travis-ci.com/user/languages/android/
+    - tools
+    - platform-tools
+    - tools
+
+    # The BuildTools version used by your project
+    - build-tools-26.0.1
+
+    # The SDK version used to compile your project
+    - android-24
+
+    # Additional components
+    - extra-google-m2repository
+    - extra-android-m2repository
+
+    # Specify at least one system image,
+    # if you need to run emulator(s) during your tests
+    - sys-img-armeabi-v7a-android-24
+
 matrix:
     include:
         - os: linux
-          dist: precise
           language: android
           sudo: required
-          android:
-            components:
-              # Uncomment the lines below if you want to
-              # use the latest revision of Android SDK Tools
-              - platform-tools
-              - tools
-
-              # The BuildTools version used by your project
-              - build-tools-25.0.0
-
-              # The SDK version used to compile your project
-              - android-25
-
-              # Additional components
-              - extra-google-m2repository
-              - extra-android-m2repository
-
-              # Specify at least one system image,
-              # if you need to run emulator(s) during your tests
-              - sys-img-x86-android-24
-              - sys-img-armeabi-v7a-android-24
+          dist: trusty
+          jdk: oraclejdk8
+          services:
+            - docker
+          env:
+            # Note that on trusty the emulator defaults to qemu2 (at least for
+            # the image specified), which broke the old -noaudio option so we
+            # set this environment variable. The reason we specify no audio is:
+            # "Some Linux and Windows computers have faulty audio drivers that
+            # cause different symptoms, such as preventing the emulator from
+            # starting."
+            # -From https://developer.android.com/studio/run/emulator-commandline.html
+            - QEMU_AUDIO_DRV=none
           script:
-            - echo y | android update sdk -u --filter android-24
-            # Launch Android emulator
-            #- echo no | android create avd --force -n test -t android-21 --abi x86
-            - echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a
-            - emulator -avd test -no-audio -no-window &
+            # Update all packages
+            - echo y | sdkmanager --update
+            # List android targets for debug
+            - avdmanager list
+            # Create avd
+            - echo no | avdmanager create avd -f -n test -k "system-images;android-24;default;armeabi-v7a"
+            # Launch emulator
+            - $ANDROID_HOME/emulator/emulator -avd test -no-window &
             - android-wait-for-emulator
             - travis_wait 30 npm run test-platform -- 'android'
         - os: osx
           language: objective-c
-          osx_image: xcode8
-          before_install:
-            - brew install couchdb
-            - brew services start couchdb
+          osx_image: xcode8.3
           script:
             - travis_wait 30 npm run test-platform -- 'ios'
 
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install couchdb && brew services start couchdb ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker pull apache/couchdb:1.7.1 && docker run -d -p 5984:5984 apache/couchdb:1.7.1 ; fi
+
 before_script:
-    # Update npm
-    - npm update -g npm
+    # Make sure CouchDB is up
+    - while [ $? -ne 0 ]; do sleep 1 && curl -v http://localhost:5984; done
     # Run setup to replicate animaldb
     - ./setup.rb
     - nvm install 6
     - npm install
     # for now only check javascript production source files follow guidelines.
     - npm run lint
-
-before_install:
-    - jdk_switcher use oraclejdk8

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "jscs": "~3.0.7"
   },
   "scripts": {
-    "cpm": "cordova-paramedic --plugin . --verbose --timeout 1200000 ",
+    "cpm": "cordova-paramedic --plugin . --verbose --timeout 1800000 ",
     "compile": "npm run compile-platform -- 'ios' && npm run compile-platform -- 'android'",
     "compile-platform": "npm run cpm -- --justbuild --platform ",
     "test-platform": "npm run cpm -- --platform ",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "q": "~1.4.1"
   },
   "devDependencies": {
-    "cordova": "~6.4.0",
+    "cordova": "^7.1.0",
     "cordova-paramedic": "~0.5.0",
     "jscs": "~3.0.7"
   },

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "cloudant-sync-tests",
+  "version": "0.4.2-SNAPSHOT",
+  "description": "Tests for the cloudant-sync plugin",
+  "cordova": {
+    "id": "cloudant-sync-tests",
+    "platforms": [
+      "ios",
+      "android"
+    ]
+  },
+  "keywords": [
+    "ecosystem:cordova"
+  ],
+  "author": "IBM Cloudant",
+  "license": "Apache-2.0"
+}

--- a/www/datastoremanager.js
+++ b/www/datastoremanager.js
@@ -716,12 +716,16 @@ function validateDocumentRevision(documentRevision) {
             'documentRevision contained invalid attachment.  ' +
             attachmentName + ' had no data');
       }
-
+      // Turn off linting for the content_type identifier since it is lowercase
+      // to match the JSON of CouchDB
+      // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
       if (_.isEmpty(attachment.content_type)) {
         throw new Error(
             'documentRevision contained invalid attachment.  ' +
             attachmentName + ' had no content_type');
       }
+      // Re-enable the rule
+      // jscs:enable requireCamelCaseOrUpperCaseIdentifiers
     }
   }
 }


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/sync-cordova-plugin/blob/master/DCO1.1.txt)
- [x] You have [added tests](https://github.com/cloudant/sync-cordova-plugin/blob/master/CONTRIBUTING.md#adding-tests) for any code changes - **no code change**
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/sync-cordova-plugin/blob/master/CHANGES.md) - **no code change**
- [x] You have completed the PR template below:

## What

Updated Travis CI configuration and miscellaneous build/lint/test fixes.

## How

* Fixed lint check that was silently failing.
* Increased test timeout for slow times.
* Updated Apache Cordova version for testing to latest 7.1.0 and added new required package.json for the test project.
* Updated travis configuration
    * Updated to `dist: trusty` for trusty LTS based images.
    * Updated Android build-tools version to 26.0.1.
    * Fixed Android SDK version at 24.
    * Updated emulator launch for new Android build-tools.
    * Removed un-needed global npm update.
    * Added `apache/couchdb` docker container instead of using the Travis `couchdb` service, which was not available on the Android trusty image.
    * Added wait for CouchDB endpoint.
    * Updated to `xcode8.3` image (8 is deprecated).
    * Moved configurations to correct place and added os if checks.

## Testing

CI passes.

## Issues

Fixes #91 
