### PR TITLE
Moved to API level 19 for faster emulation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ android:
     - build-tools-26.0.1
 
     # The SDK version used to compile your project
-    - android-24
+    - android-19
 
     # Additional components
     - extra-google-m2repository
@@ -20,7 +20,7 @@ android:
 
     # Specify at least one system image,
     # if you need to run emulator(s) during your tests
-    - sys-img-armeabi-v7a-android-24
+    - sys-img-armeabi-v7a-android-19
 
 matrix:
     include:
@@ -46,7 +46,7 @@ matrix:
             # List android targets for debug
             - avdmanager list
             # Create avd
-            - echo no | avdmanager create avd -f -n test -k "system-images;android-24;default;armeabi-v7a"
+            - echo no | avdmanager create avd -f -n test -k "system-images;android-19;default;armeabi-v7a"
             # Launch emulator
             - $ANDROID_HOME/emulator/emulator -avd test -no-window &
             - android-wait-for-emulator

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ libraries.
 
 ## Supported Platforms
 
-* Android
+* Android (API level 19+)[See known issues](#known-issues)
 * iOS
 
 ## Using in your project
@@ -215,7 +215,10 @@ Learn more about this essential process in the
 
 ## Known Issues
 
-None at this time
+Nested JSON elements do not work correctly on Android API levels <19. This is because the
+[`JsonObject#wrap()`](https://developer.android.com/reference/org/json/JSONObject.html#wrap(java.lang.Object))
+used internally in the platform is only available since API level 19.
+If you have no nested JSON elements the minimum API level is 16.
 
 ## Contributors
 


### PR DESCRIPTION


Thanks for your hard work, please ensure all items are complete before opening a PR.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/sync-cordova-plugin/blob/master/DCO1.1.txt)
- [x] You have [added tests](https://github.com/cloudant/sync-cordova-plugin/blob/master/CONTRIBUTING.md#adding-tests) for any code changes - N/A CI change
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/sync-cordova-plugin/blob/master/CHANGES.md) - N/A CI change
- [x] You have completed the PR template below:

## What

Changed Android API level in Travis, added `README` note about API level.

## How

Changed to API level 19 for testing.
Updated `README` for API level.

## Testing

Existing CI passes.

## Issues

N/A
